### PR TITLE
Add Googletest dependency and instructions 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,23 +10,34 @@ set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 find_package(GTest CONFIG REQUIRED)
 
 # ---- SDL2: prefer CONFIG, fallback to pkg-config ----
-set(SDL2_MODE "")
-find_package(SDL2 CONFIG QUIET)
-if (SDL2_FOUND)
-    set(SDL2_MODE "CONFIG")  # provides SDL2::SDL2, SDL2::SDL2main (on Windows)
-else()
+set(_SDL2_TARGET "")
+if (TARGET SDL2::SDL2)
+    set(_SDL2_TARGET SDL2::SDL2)
+elseif (TARGET SDL2::SDL2-static)
+    set(_SDL2_TARGET SDL2::SDL2-static)
+endif()
+
+if (NOT _SDL2_TARGET)
+    # Try the CMake module (FindSDL2). Some distros only expose variables.
+    find_package(SDL2 QUIET)  # module mode
+    if (TARGET SDL2::SDL2)
+        set(_SDL2_TARGET SDL2::SDL2)
+    elseif (SDL2_FOUND AND SDL2_INCLUDE_DIRS AND SDL2_LIBRARIES)
+        add_library(SDL2::SDL2 INTERFACE IMPORTED)
+        target_include_directories(SDL2::SDL2 INTERFACE ${SDL2_INCLUDE_DIRS})
+        target_link_libraries(SDL2::SDL2 INTERFACE ${SDL2_LIBRARIES})
+        set(_SDL2_TARGET SDL2::SDL2)
+    endif()
+endif()
+
+if (NOT _SDL2_TARGET)
+    # Fallback: pkg-config
     find_package(PkgConfig REQUIRED)
     pkg_check_modules(SDL2 REQUIRED sdl2)
-    set(SDL2_MODE "PKG")
-    # Create a compatible imported target so the rest of the file is uniform.
     add_library(SDL2::SDL2 INTERFACE IMPORTED)
     target_include_directories(SDL2::SDL2 INTERFACE ${SDL2_INCLUDE_DIRS})
-    target_link_libraries(SDL2::SDL2 INTERFACE ${SDL2_LIBRARIES})
-    if (WIN32 AND SDL2_LINK_LIBRARIES)
-        # If pkg-config exposes SDL2main too
-        add_library(SDL2::SDL2main INTERFACE IMPORTED)
-        target_link_libraries(SDL2::SDL2main INTERFACE SDL2main)
-    endif()
+    target_link_libraries(SDL2::SDL2 INTERFACE ${SDL2_LINK_LIBRARIES})
+    set(_SDL2_TARGET SDL2::SDL2)
 endif()
 message(STATUS "SDL2 mode: ${SDL2_MODE}")
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,64 +1,71 @@
 cmake_minimum_required(VERSION 3.20)
-
 project(NES_Emulator LANGUAGES CXX)
 
-# ---- Cross-platform SDL2 discovery ----
-# Try modern CONFIG mode first (vcpkg on Win/Linux/macOS; sometimes Homebrew too)
-set(SDL2_MODE "")
-find_package(SDL2 CONFIG QUIET)
-
-if (SDL2_FOUND)
-    set(SDL2_MODE "CONFIG")
-else()
-    # Fallback to pkg-config (apt/brew install sdl2)
-    find_package(PkgConfig QUIET)
-    if (PkgConfig_FOUND)
-        pkg_check_modules(SDL2 REQUIRED sdl2)
-        set(SDL2_MODE "PKG")
-    else()
-        message(FATAL_ERROR
-                "SDL2 not found.\n"
-                "Option A) Use vcpkg and pass -DCMAKE_TOOLCHAIN_FILE=... (recommended)\n"
-                "Option B) Install SDL2 via your OS package manager and ensure pkg-config is available."
-        )
-    endif()
-endif()
-
-message(STATUS "SDL2 mode: ${SDL2_MODE}")
-
-message(STATUS "SDL2 mode: ${SDL2_MODE}")
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
-# macOS: ensure SDK headers are visible to the compiler and CLion
+# ---- GoogleTest (imported targets) ----
+find_package(GTest CONFIG REQUIRED)
+
+# ---- SDL2: prefer CONFIG, fallback to pkg-config ----
+set(SDL2_MODE "")
+find_package(SDL2 CONFIG QUIET)
+if (SDL2_FOUND)
+    set(SDL2_MODE "CONFIG")  # provides SDL2::SDL2, SDL2::SDL2main (on Windows)
+else()
+    find_package(PkgConfig REQUIRED)
+    pkg_check_modules(SDL2 REQUIRED sdl2)
+    set(SDL2_MODE "PKG")
+    # Create a compatible imported target so the rest of the file is uniform.
+    add_library(SDL2::SDL2 INTERFACE IMPORTED)
+    target_include_directories(SDL2::SDL2 INTERFACE ${SDL2_INCLUDE_DIRS})
+    target_link_libraries(SDL2::SDL2 INTERFACE ${SDL2_LIBRARIES})
+    if (WIN32 AND SDL2_LINK_LIBRARIES)
+        # If pkg-config exposes SDL2main too
+        add_library(SDL2::SDL2main INTERFACE IMPORTED)
+        target_link_libraries(SDL2::SDL2main INTERFACE SDL2main)
+    endif()
+endif()
+message(STATUS "SDL2 mode: ${SDL2_MODE}")
+
+# ---- macOS SDK convenience (optional) ----
 if(APPLE)
     execute_process(COMMAND xcrun --show-sdk-path
             OUTPUT_VARIABLE SDK_PATH
             OUTPUT_STRIP_TRAILING_WHITESPACE)
     if(SDK_PATH)
-        set(CMAKE_OSX_SYSROOT "${SDK_PATH}")
         add_compile_options(-isysroot "${SDK_PATH}")
         add_link_options(-isysroot "${SDK_PATH}")
     endif()
 endif()
 
-if(WIN32)
-    include_directories(${SDL2_INCLUDE_DIR})
-    link_directories(${SDL2_LIB_DIR})
+# ---- Library: all sources under src/, EXCEPT main.cpp ----
+file(GLOB_RECURSE NES_SOURCES CONFIGURE_DEPENDS "${PROJECT_SOURCE_DIR}/src/*.cpp")
+list(FILTER NES_SOURCES EXCLUDE REGEX ".*/main\\.cpp$")
 
-    set(SDL2_LIBS SDL2 SDL2main)
+add_library(nes_lib ${NES_SOURCES})
+target_include_directories(nes_lib
+        PUBLIC
+        $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
+        $<INSTALL_INTERFACE:include>
+)
 
-else()
-    find_package(PkgConfig REQUIRED)
-    pkg_check_modules(SDL2 REQUIRED sdl2)
+# ---- Executable with main.cpp; link SDL only here ----
+add_executable(nes_emu ${PROJECT_SOURCE_DIR}/src/main.cpp)
+target_link_libraries(nes_emu PRIVATE nes_lib SDL2::SDL2)
+
+if (WIN32)
+    # Many SDL2 configs want SDL2main on Windows
+    if (TARGET SDL2::SDL2main)
+        target_link_libraries(nes_emu PRIVATE SDL2::SDL2main)
+    endif()
 endif()
 
-add_subdirectory(src)
-
+# ---- Tests ----
 option(BUILD_TESTING "Build tests" ON)
-if(BUILD_TESTING)
+if (BUILD_TESTING)
     enable_testing()
-    add_subdirectory(tests)
+    add_subdirectory(tests)  # your tests CMake should link nes_lib and GTest::gtest_main
 endif()

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Proves our toolchain, repo health, and collaboration for Progress Report #1.
 
 ### macOS
 ```bash
-brew install sdl2 cmake
+brew install sdl2 cmake googletest
 make build
 make run
 make test
@@ -22,7 +22,10 @@ make test
 
 ### Ubuntu/Debian
 ```bash
-sudo apt-get update && sudo apt-get install -y libsdl2-dev cmake g++
+sudo apt-get update && sudo apt-get install -y libsdl2-dev cmake g++ libgtest-dev libgmock-dev
+sudo cmake -S /usr/src/googletest -B /tmp/build-gtest
+sudo cmake --build /tmp/build-gtest --config Release
+sudo cmake --install /tmp/build-gtest
 make build
 make run
 make test

--- a/README.md
+++ b/README.md
@@ -37,11 +37,14 @@ PowerShell:
 cd C:\
 git clone https://github.com/microsoft/vcpkg.git
 C:\vcpkg\bootstrap-vcpkg.bat
-C:\vcpkg\vcpkg install sdl2:x64-windows
+C:\vcpkg\vcpkg install sdl2:x64-windows gtest:x64-windows
 C:\vcpkg\vcpkg integrate install
 Switch to local project directory
 choco install -y cmake
-cmake -S . -B build -G "Visual Studio 17 2022" -A x64 -DBUILD_TESTING=ON
+cmake -S . -B build `
+  -G "Visual Studio 17 2022" -A x64 `
+  -DBUILD_TESTING=ON `
+  -DCMAKE_TOOLCHAIN_FILE=C:/vcpkg/scripts/buildsystems/vcpkg.cmake
 cmake --build build --config Release
 ./build/src/Release/nes_emu.exe
 ./build/tests/Release/tests.exe

--- a/include/nes/cpu.hpp
+++ b/include/nes/cpu.hpp
@@ -1,3 +1,4 @@
 #pragma once
 #include <cstdint>
-namespace nes { class CPU { public: void reset() {} void step() {} }; }
+#include <string>
+namespace nes { class CPU { public: void reset(); void step(); std::string lookupInstruction(int); }; }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,4 +1,4 @@
-#include <SDL2/SDL.h>
+#include <SDL.h>
 #include <cstdio>
 #include <string>
 

--- a/src/nes/cpu.cpp
+++ b/src/nes/cpu.cpp
@@ -1,0 +1,13 @@
+//
+// Created by Chris Blum on 11/4/25.
+//
+#include "nes/cpu.hpp"
+#include <string>
+
+namespace nes {
+    void CPU::reset() {}
+    void CPU::step() {}
+	std::string CPU::lookupInstruction(int opcode) {
+		switch (opcode) { case 0x01: return "ORA"; default: return "???"; }
+	}
+}

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,1 +1,18 @@
+
+find_package(GTest CONFIG REQUIRED)
+
+
+add_executable(opcode_tests
+        cpu/opcode_tests.cpp
+)
+
+target_link_libraries(opcode_tests
+        PRIVATE
+        nes_lib
+        GTest::gtest_main
+)
+
+include(GoogleTest)
+gtest_discover_tests(opcode_tests)
+
 add_executable(tests test_sanity.cpp)

--- a/tests/cpu/opcode_tests.cpp
+++ b/tests/cpu/opcode_tests.cpp
@@ -1,0 +1,17 @@
+//
+// Created by Chris Blum on 11/4/25.
+//
+#include "nes/cpu.hpp"
+#include <gtest/gtest.h>
+
+namespace {
+
+	// Tests the ORA opcode
+	TEST(OpcodeTest, Ora) {
+	std::string ora = "ORA";
+	nes::CPU cpu;
+	EXPECT_EQ(ora, cpu.lookupInstruction(1));
+	// EXPECT_EQ(ora, cpu.lookupInstruction(2));
+}
+
+}


### PR DESCRIPTION
Implement support for Googletest (gtest) unit testing framework and added instructions for Windows/MacOS/Linux for installing the Googletest library to the Quick Start instructions.
