### PR TITLE
Design and Develop GenAI Refactor improvements.

### DIFF
--- a/include/nes/apu.hpp
+++ b/include/nes/apu.hpp
@@ -7,31 +7,23 @@ namespace nes {
 class Memory;
 
 // From https://www.nesdev.org/wiki/APU_Envelope
-// In a synthesizer, an envelope is the way a sound's parameter changes over time.
-// The NES APU has an envelope generator that controls the volume in one of two ways:
-// it can generate a decreasing saw envelope (like a decay phase of an ADSR) with optional looping,
-    
-// or it can generate a constant volume that a more sophisticated software envelope generator
-// can manipulate.
-// Volume values are practically linear (see: APU Mixer).
-// Each volume envelope unit contains the following: start flag, divider, and decay level counter.
-// When clocked by the frame counter, one of two actions occurs:
-// if the start flag is clear, the divider is clocked,
-// otherwise the start flag is cleared, the decay level counter is loaded with 15, and
-// the divider's period is immediately reloaded.
-// When the divider is clocked while at 0, it is loaded with V and clocks the decay level counter.
-// Then one of two actions occurs:
-// If the counter is non-zero, it is decremented,
-// otherwise if the loop flag is set, the decay level counter is loaded with 15.
-// The envelope unit's volume output depends on the constant volume flag:
-// if set, the envelope parameter directly sets the volume,
-// otherwise the decay level is the current volume.
-// The constant volume flag has no effect besides selecting the volume source;
-// the decay level will still be updated when constant volume is selected.
-// Each of the three envelope units' output is fed through additional gates at
-// the sweep unit (pulse only),
-// waveform generator (sequencer or LFSR), and
-// length counter.
+//
+// In a synthesizer, an envelope controls how a sound's volume changes over
+// time.  The NES APU envelope generator either produces a decreasing saw
+// (with optional looping) or holds a constant volume for use by a software
+// envelope.  Volume values are practically linear (see APU Mixer).
+//
+// Each envelope unit contains: start flag, divider, and decay level counter.
+//
+// Clocking (quarter-frame):
+//   - If start flag is clear, the divider is clocked.
+//   - Otherwise the start flag is cleared, decay reloads to 15, and the
+//     divider period is immediately reloaded.
+//   - When the divider reaches 0 it reloads from volume_period and clocks
+//     the decay counter: decrement if non-zero, else reload to 15 if looping.
+//
+// Output: constant_volume_flag ? volume_period : decay_level
+//
 //                                    Loop flag
 //                                         |
 //                        Start flag  +.   |   Constant volume
@@ -44,651 +36,310 @@ class Memory;
 //                         Envelope parameter +> |
 class Envelope {
 public:
-    //  Configuration (set by CPU writes to $4000/$4004)
-
-    // Also serves as length counter halt
-    bool loop_flag = false;
-
-    // true = use volume directly, false = use decay
-    bool constant_volume_flag = false;
-
-    // 4 bits: either constant volume OR envelope period
-    uint8_t volume_period = 0;
-
-    //  Internal state
-    // Set when note starts, triggers envelope restart
-    bool start_flag = false;
-
-    // Current envelope volume (counts down 15->0)
-    uint8_t decay_level = 0;
-
-    // Divider countdown (reloads from volume_period)
-    uint8_t divider = 0;
-
-    // Clock the envelope (called on quarter-frame)
     void clock();
-
-    // Get current output volume (0-15)
     uint8_t output() const;
-
-    // Reset the envelope state
     void reset();
+
+    // Configuration — set by CPU writes to $4000/$4004/$400C
+    bool loop_flag             = false; // also serves as length counter halt
+    bool constant_volume_flag  = false; // true = use volume_period directly
+    uint8_t volume_period      = 0;    // 4-bit: constant volume OR envelope period
+
+    // Internal state
+    bool    start_flag  = false; // triggers envelope restart on next clock
+    uint8_t decay_level = 0;    // current volume (counts 15→0)
+    uint8_t divider     = 0;    // countdown; reloads from volume_period
 };
 
 
-// The sweep unit automatically adjusts the channel's period (frequency) over
-// time, creating pitch bends. It can sweep the pitch UP (decreasing period)
-// or DOWN (increasing period).
 // From https://www.nesdev.org/wiki/APU_Sweep
-//    The sweep unit continuously calculates each pulse channel's target period in this way:
-//    Reads the pulse channel's 11-bit raw timer period
-//    Shifts timer period right by the shift count, producing the change amount.
-//    If the negate flag is true, the change amount is made negative.
-//    The target period is the sum of the current period and the change amount, clamped to zero if this sum is negative.
-//    For example, if the negate flag is false and the shift amount is zero, the change amount equals the current
-//    period, making the target period equal to twice the current period.
-//    The two pulse channels have their adders' carry inputs wired differently, which produces different results
-//    when each channel's change amount is made negative:
-//    Pulse 1 adds the ones' complement (−c − 1). Making 20 negative produces a change amount of −21.
-//    Pulse 2 adds the two's complement (−c). Making 20 negative produces a change amount of −20.
-//    Whenever the current period or sweep setting changes, whether by $400x writes or by sweep updating the period,
-//    the target period also changes.
-
+//
+// The sweep unit adjusts the pulse channel's period over time, creating
+// pitch bends.  It continuously computes a target period from the current
+// period, a shift count, and a negate flag.  Pulse 1 uses ones'-complement
+// negation (−c − 1); Pulse 2 uses twos'-complement (−c).
+//
+// Muting: the channel is silenced when period < 8 **or** the computed
+// target period exceeds $7FF.
 class SweepUnit {
 public:
-
-    //  configuration set by CPU writes to $4001/$4005
-
-    // sweep on/off
-    bool enabled = false;
-
-    // divider period (3 bits, 0-7)
-    uint8_t period = 0;
-
-    // false = add (pitch down), true = subtract (pitch up)
-    bool negate = false;
-
-    // 3-bit shift amount for period adjustment SSS = 0 behaves like enabled = false
-    uint8_t shift = 0;
-
-    //  internal state
-    // set when sweep register written
-    bool reload_flag = false;
-
-    // current divider countdown
-    uint8_t divider = 0;
-
-    //  channel identity (affects negation calculation)
-    // Pulse 1 uses one's complement negation
-    // Pulse 2 uses two's complement negation
-    bool is_pulse1 = true;
-
-    // calculate target period given current period
-    // returns the period the channel would have after one sweep adjustment
     uint16_t calculate_target_period(uint16_t current_period) const;
-
-    // check if channel should be muted due to sweep
-    // muting occurs if period < 8 OR target period > 0x7FF
-    static bool is_muting(uint16_t current_period) ;
-
-    // clock the sweep unit called on half-frame
-    // returns true if timer period should be updated
     bool clock(uint16_t& timer_period);
-
-    // reset all sweep state
     void reset();
+
+    // Returns true when the target period would silence the channel.
+    static bool is_muting(uint16_t target_period);
+
+    // Configuration — set by CPU writes to $4001/$4005
+    bool    enabled  = false;
+    uint8_t period   = 0;    // divider period (3 bits, 0-7)
+    bool    negate   = false; // true = subtract (pitch up)
+    uint8_t shift    = 0;    // 3-bit shift count; 0 behaves like enabled=false
+
+    // Internal state
+    bool    reload_flag = false;
+    uint8_t divider     = 0;
+
+    // Channel identity — affects negation; set once at construction, never reset.
+    bool is_channel1 = true;
 };
 
-// From https://www.nesdev.org/wiki/APU_Length_Counter
-// The length counter controls how long a note plays. When a note starts,
-// the counter is loaded with a value from a lookup table. The counter then
-// counts down once per frame-counter half-frame. When it reaches 0, the
-// channel is silenced.
-//
-// This allows the game to play a note of a specific duration without needing
-// to manually turn it off - useful for sound effects and music timing.
-//
-// The length counter can be "halted" (paused) by setting the halt flag.
-// When halted, it stops counting and the note sustains indefinitely.
-// This is controlled by the same bit as the envelope loop flag.
-//
-// LENGTH COUNTER LOOKUP TABLE:
-// The table contains values designed for musical timing. The game writes
-// a 5-bit index (0-31) and gets a specific counter value.
-//
-// Index: Value pairs (values represent frame counter half-frames):
-//   0x00: 10    0x01: 254   0x02: 20    0x03: 2
-//   0x04: 40    0x05: 4     0x06: 80    0x07: 6
-//   ... and so on (see implementation for full table)
 
+// From https://www.nesdev.org/wiki/APU_Length_Counter
+//
+// The length counter provides automatic note duration.  On load it receives
+// a value from a hardware lookup table indexed by a 5-bit field.  It counts
+// down once per half-frame; when it reaches 0 the channel is silenced.
+// Setting the halt flag pauses counting (note sustains indefinitely).
 class LengthCounter {
 public:
-
-    // when true, counter doesn't decrement
-    bool halt = false;
-
-    // current counter value
-    uint8_t counter = 0;
-
-    // load counter from lookup table called when $4003/$4007 written
-    void load(uint8_t index);
-
-    // clock the counter called on half-frame
+    void load(uint8_t table_index);
     void clock();
 
-    // check if counter is non-zero aka channel active
     bool is_active() const { return counter > 0; }
+    void clear()           { counter = 0; }
+    void reset()           { counter = 0; }
 
-    // force counter to 0 when channel disabled via $4015
-    void clear() { counter = 0; }
+    bool    halt    = false;
+    uint8_t counter = 0;
 
-    // reset all state
-    void reset();
-
-    // static lookup table for length counter values
-    static const uint8_t LENGTH_TABLE[32];
+    static const uint8_t TABLE[32];
 };
 
 
 // From https://www.nesdev.org/wiki/APU_Pulse
-// The complete pulse channel combining all the above components:
 //
 //                  Sweep -----> Timer
-//                    |            |
-//                    |            | clocks
+//                    |            |            clocks
 //                    |            v
 //                    |        Sequencer   Length Counter
 //                    |            |             |
-//                    |            | 0 or 1      |
 //                    v            v             v
-// Envelope -------> Gate -----> Gate -------> Gate --->(to mixer)
-// multiplies by
-// volume 0-15
+// Envelope -------> Gate -----> Gate -------> Gate ---> (to mixer)
 //
-//   Gate output is 0 if any is true:
-//    Sequencer output is 0
-//    Length counter is 0
-//    Sweep unit is muting
-//
-//   Timer runs at CPU clock / 2 (894.886 kHz on NTSC)
-//   Period of 0 = timer runs every 2 CPU cycles
-//   Audible range: ~54 Hz (period 0x7FF) to ~12.4 kHz (period 8)
-//   Periods < 8 are muted (ultrasonic, would alias badly)
-//
-// Registers:
+// Registers ($4000-$4003 for Pulse 1, $4004-$4007 for Pulse 2):
 //   $4000/$4004: DDLC VVVV  Duty, Length halt, Constant vol, Volume/Period
 //   $4001/$4005: EPPP NSSS  Sweep Enable, Period, Negate, Shift
 //   $4002/$4006: TTTT TTTT  Timer low 8 bits
 //   $4003/$4007: LLLL LTTT  Length counter load, Timer high 3 bits
-//
 class PulseChannel {
 public:
-    Envelope envelope;
-    SweepUnit sweep;
+    explicit PulseChannel(bool is_channel1 = true);
+
+    void write_register(uint8_t reg, uint8_t value);
+    void clock_timer();
+    void clock_envelope();
+    void clock_length_and_sweep();
+    uint8_t output() const;
+    void reset();
+
+    // Sub-units
+    Envelope      envelope;
+    SweepUnit     sweep;
     LengthCounter length_counter;
 
-    // Timer controls frequency
-    // The timer is an 11-bit value (0-2047). The actual period in CPU cycle is (timer_period + 1) * 2 where
-    // lower values = higher frequency.
+    // Timer (11-bit period + countdown)
+    uint16_t timer_period   = 0;
+    uint16_t timer_counter  = 0;
 
-    // 11-bit period value from registers $4002 + lower 3 bits of $4003 for pulse 1
-    // and $4006 (low) + $4007's lower 3 bits (high) for pulse 2
-    uint16_t timer_period = 0;
+    // Duty cycle sequencer (8-step, 4 patterns)
+    uint8_t duty_mode           = 0; // 0-3
+    uint8_t sequencer_position  = 0; // 0-7
 
-    // countdown timer that reloads from table and clocks the shift register on 0
-    uint16_t timer_counter = 0;
+    bool enabled = false; // controlled via $4015
 
-    //  Duty cycle sequencer 
-    // (8-step sequence, 4 different duty patterns)
-    //
-    //   12.5%: 0 1 0 0 0 0 0 0  (1 high, 7 low)
-    //   25%:   0 1 1 0 0 0 0 0  (2 high, 6 low)
-    //   50%:   0 1 1 1 1 0 0 0  (4 high, 4 low)
-    //   75%:   1 0 0 1 1 1 1 1  (6 high, 2 low)
-    // The sequencer steps through 8 positions, outputting 0 or 1 based on
-    // the selected duty cycle pattern.
-
-    // 0-3: selects one of 4 duty patterns
-    uint8_t duty_mode = 0;
-
-    // 0-7: current position in sequence
-    uint8_t sequencer_position = 0;
-
-    //  channel state
-    bool enabled = false;             // set via $4015 status register
-
-    // Duty cycle lookup table
-    // Each row is a duty pattern, each column is a sequencer position.
-    // The sequencer counts down and loops (7,6,5,4,3,2,1,0,7,6,5...)
     static const uint8_t DUTY_TABLE[4][8];
-
-    // specify if this is pulse 1 (affects sweep negation)
-    explicit PulseChannel(bool is_pulse1 = true);
-
-    // write to channel registers
-    void write_register(uint8_t reg, uint8_t value);
-
-    // clock the timer called every APU cycle = every 2 CPU cycles
-    void clock_timer();
-
-    // clock envelope called on frame counter quarter-frame see clock_quarter_frame() in APU class
-    void clock_envelope();
-
-    // clock length counter and sweep called on frame counter half-frame
-    void clock_length_and_sweep();
-
-    // get current output sample (0-15)
-    uint8_t output() const;
-
-    // reset all state
-    void reset();
 };
 
+
 // From https://www.nesdev.org/wiki/APU_Triangle
-//  The NES APU triangle channel generates a pseudo-triangle wave. It has no volume control;
-//  the waveform is either cycling or suspended. It includes a linear counter,
-//  an extra duration timer of higher accuracy than the length counter.
-// The triangle channel contains the following:
-// timer,
-// length counter,
-// linear counter,
-// linear counter reload flag,
-// control flag,
-// sequencer.
 //
 //      Linear Counter   Length Counter
 //            |                |
 //            v                v
-//Timer ---> Gate ----------> Gate ---> Sequencer ---> (to mixer)
+// Timer ---> Gate ----------> Gate ---> Sequencer ---> (to mixer)
 //
-// Unlike the pulse channels, the triangle channel supports frequencies up to the
-// maximum frequency the timer will allow, meaning frequencies up to fCPU/32
-// (about 55.9 kHz for NTSC) are possible - far above the audible range
-// f = fCPU/(32*(tval + 1))
-// tval = fCPU/(32*f) - 1
-
+// The triangle channel has no volume control; the waveform is either
+// cycling or suspended.  It includes a linear counter for finer-grained
+// duration control than the length counter alone.
+// Timer ticks at CPU clock rate (not halved like Pulse/Noise).
 class Triangle {
 public:
+    void write_register(uint8_t reg, uint8_t value);
+    void clock_timer();
+    void clock_linear_counter();
+    uint8_t output() const;
+    void reset();
+
     LengthCounter length_counter;
 
-    // set by bit 7 of $4008
-    // this bit is also the length halt
-    bool control_flag = false;
+    bool    control_flag         = false; // bit 7 of $4008; also length halt
+    uint8_t counter_reload_value = 0;    // bits 6-0 of $4008
+    uint8_t linear_counter       = 0;
+    bool    linear_reload_flag   = false;
 
-    // set by low 6-0 bits of $4008
-    // linear counter is reloaded with this value if linear_reload_flag is set
-    uint8_t counter_reload_value = 0;
+    uint16_t timer_period   = 0;
+    uint16_t timer_counter  = 0;
+    uint8_t  sequencer_step = 0;
 
-    // linear counter is clocked by the frame counter not the triangle timer
-    uint8_t linear_counter = 0;
+    bool enabled = false; // $4015 bit 2
 
-    // when set, linear_counter is reloaded from counter_reload_value
-    // cleared only if control_flag == 0 after the clock
-    bool linear_reload_flag = false;
-
-    // timer_period controls frequency
-    // the timer is an 11-bit value (0-2047). Unlike Pulse, Triangle timer ticks at the rate of the CPU clock.
-    // 11-bit period value from lower 3 bits of $400B (high) + $400A (low)
-    uint16_t timer_period = 0;
-
-    // countdown timer reloads from timer_period and clocks the sequencer when it reaches 0
-    uint16_t timer_counter = 0;
-
-    // index into sequencer table
-    uint8_t sequencer_step = 0;
-
-    // $4015 bit 2 controls whether Triangle runs
-    bool enabled = false;
-
-    // The sequencer is clocked by the timer as long as both the linear counter and the length counter are nonzero.
-    // The sequencer sends the following looping 32-step sequence of values to the mixer:
-    // 15, 14, 13, 12, 11, 10,  9,  8,  7,  6,  5,  4,  3,  2,  1,  0
-    // 0,  1,  2,  3,  4,  5,  6,  7,  8,  9, 10, 11, 12, 13, 14, 15
-    static const uint8_t SEQUENCER_TABLE[32];
-
-    // write to channel registers
-    void write_register(uint8_t reg, uint8_t value);
-
-    // clock the timer called every APU cycle = every CPU cycle (Triangle only!)
-    void clock_timer();
-
-    // clock the linear counter by the frame counter
-    void clock_linear_counter();
-
-    // get current output sample (0-15)
-    uint8_t output() const;
-
-    // reset all triangle state
-    void reset();
+    static const uint8_t SEQUENCE[32];
 };
 
-// From: https://www.nesdev.org/wiki/APU_Noise
-// The NES APU noise channel generates pseudo-random 1-bit noise at 16 different frequencies.
-//
-// The noise channel contains the following: envelope generator, timer, Linear Feedback Shift Register, length counter.
+
+// From https://www.nesdev.org/wiki/APU_Noise
 //
 //       Timer --> Shift Register   Length Counter
 //                       |                |
 //                       v                v
 //    Envelope -------> Gate ----------> Gate --> (to mixer)
-class Noise
-{
+//
+// The noise channel generates pseudo-random 1-bit noise at 16 frequencies
+// via a 15-bit LFSR.  Mode flag selects between a 32767-step sequence
+// (long / bit 1) and a 93-or-31-step sequence (short / bit 6).
+class Noise {
 public:
-    Envelope envelope;
+    void write_register(uint8_t reg, uint8_t value);
+    void clock_timer();
+    void clock_envelope();
+    void clock_shift_register();
+    uint8_t output() const;
+    void reset();
+
+    Envelope      envelope;
     LengthCounter length_counter;
 
-    // length counter halt flag $400C bit 4
-    bool length_counter_halt = false;
+    bool    mode_flag          = false; // bit 7 of $400E
+    uint8_t timer_period_index = 0;    // bits 3-0 of $400E
+    uint16_t timer_counter     = 0;
+    uint16_t lfsr              = 1;    // 15-bit shift register; power-on = 1
 
-    // constant volume $400C bit 5
-    bool constant_volume_flag = false;
+    bool enabled = false; // controlled via $4015
 
-    // bits 3-0 of $400C
-    uint8_t volume_envelope_divider_period = 0;
-
-    //  mode is set by bit 7 of $400E
-    bool mode_flag = false;
-
-    // bits 3-0 of $400E
-    uint8_t timer_period_index = 0;
-
-    // countdown timer that reloads from table and clocks the shift register on 0
-    uint16_t timer_counter = 0;
-
-    // The timer period is set to the entry timer_period_index of a lookup table
-    // which represents how many APU cycles happen between shift register clocks
-    // (half the CPU-cycle values shown on NES Dev Wiki).
-    // We only implement NTSC periods and ignore the 16 possible PAL values, so
-    // a 1-dimension table suffices. The index corresponds to $400E bits 3–0
-    // of timer_period_index. We inline to reduce confusion.
-    inline static constexpr uint16_t TIMER_PERIOD_IN_APU_TICKS[16] = {
-        2,    // $0:  4  CPU cycles
-        4,    // $1:  8
-        8,    // $2:  16
-       16,    // $3:  32
-       32,    // $4:  64
-       48,    // $5:  96
-       64,    // $6:  128
-       80,    // $7:  160
-      101,    // $8:  202
-      127,    // $9:  254
-      190,    // $A:  380
-      254,    // $B:  508
-      381,    // $C:  762
-      508,    // $D:  1016
-     1017,    // $E:  2034
-     2034     // $F:  4068 (old hardware listed 2046 which makes rumbly sounds sound kinda wrong)
-   };
-
-    // The shift register is 15 bits wide, with bits numbered
-    // 14 - 13 - 12 - 11 - 10 - 9 - 8 - 7 - 6 - 5 - 4 - 3 - 2 - 1 - 0
-    // When the timer clocks the shift register, the following actions occur in order:
-    // Fedback is calculated as the exclusive-OR of bit 0 and one other bit:
-    // bit 6 if Mode flag is set, otherwise bit 1.
-    // The shift register is shifted right by one bit.
-    // Bit 14, the leftmost bit, is set to the feedback calculated earlier.
-    // This results in a pseudo-random bit sequence, 32767 steps long when Mode flag is clear,
-    // and randomly 93 or 31 steps long otherwise (aka long mode and short mode in some descriptions).
-    // The particular 31- or 93-step sequence depends on where in the 32767-step sequence
-    // the shift register was when Mode flag was set.
-    // The mixer receives the current envelope volume except when
-    // Bit 0 of the shift register is set, or
-    // The length counter is zero
-    // On power-up, the shift register is loaded with the value 1.
-    // We store teh 15-bit LFSR state in a uint16_t and updated with bit operations.
-    uint16_t shift_register_state = 1;
-
-    // write to channel registers
-    void write_register(uint8_t reg, uint8_t value);
-
-    // clock the timer called every APU cycle = every 2 CPU cycles
-    void clock_timer();
-
-    // clock envelope called on frame counter quarter-frame see clock_quarter_frame() in APU class
-    void clock_envelope();
-
-    // clock the shift register
-    void clock_shift_register();
-
-    // get current output sample (0-15)
-    uint8_t output() const;
-
-    // reset all noise state
-    void reset();
+    // NTSC timer period lookup (values are in APU ticks = CPU cycles / 2).
+    static constexpr uint16_t TIMER_PERIOD[16] = {
+          2,   4,   8,  16,  32,  48,  64,  80,
+        101, 127, 190, 254, 381, 508, 1017, 2034
+    };
 };
 
-// From https://www.nesdev.org/wiki/APU#Glossary
-// The delta modulation channel outputs a 7-bit PCM signal from a counter that can be driven by DPCM samples.
-// DPCM samples are stored as a stream of 1-bit deltas that control the 7-bit PCM counter that the channel outputs.
-// A bit of 1 will increment the counter, 0 will decrement, and it will clamp rather than overflow if the 7-bit range
-// is exceeded.
-// DPCM samples may loop if the loop flag in $4010 is set, and the DMC may be used to generate an IRQ when the end of
-// the sample is reached if its IRQ flag is set.
-// The playback rate is controlled by register $4010 with a 4-bit frequency index value (see APU DMC for frequency
-// lookup tables).
-// DPCM samples must begin in the memory range $C000–$FFFF at an address set by register $4012
-// (address = %11AAAAAA AA000000).
-// The length of the sample in bytes is set by register $4013 (length = %LLLL LLLL0001).
-// The $4011 register can be used to play PCM samples directly by setting the counter value at a high frequency.
-// Because this requires intensive use of the CPU, when used in games all other gameplay is usually halted to f
-// acilitate this.
-// Because of the APU's nonlinear mixing, a high value in the PCM counter reduces the volume of the triangle and
-// noise channels. This is sometimes used to apply limited volume control to the triangle channel (e.g. Super
-// Mario Bros. adjusts the counter between levels to accomplish this).
-// The DMC's IRQ can be used as an IRQ-based timer when the mapper used does not have one available.
-class DeltaModulationChannel
-{
+
+// From https://www.nesdev.org/wiki/APU_DMC
+//
+// The delta modulation channel outputs 7-bit PCM driven by a stream of
+// 1-bit deltas.  Each bit adds or subtracts 2 from the output level,
+// clamped to 0-127.  Samples reside at $C000-$FFFF and are fetched by
+// a memory reader that stalls the CPU for ~4 cycles per byte.
+class DeltaModulationChannel {
 public:
+    void write_register(uint8_t reg, uint8_t value);
+    void clock_timer();
+    uint8_t output() const;
+    void reset();
 
-    // bit 7 of $4010
-    // if true, DMC may assert IRQ when the sample finishes and loop is off
-    // otherwise DMC may not issue IRQs
-    bool irq_enable = false;
+    void attach_memory(Memory* mem);
 
-    // this is the IRQ to the CPU
-    // set when bytes_remaining = 0 and loop == false adn irq_enable == true
-    // cleared when CPU writes anything to APU status register $4015
-    bool irq_pending = false;
+    // Starts (or restarts) sample playback from the configured address/length.
+    void start_sample();
 
-    // $4015 bit 4 controls whether DMC runs
-    bool enabled = false;
+    // Configuration — set by CPU writes to $4010-$4013
+    bool    irq_enabled     = false;
+    bool    loop            = false;
+    uint8_t rate_index      = 0;
+    uint8_t output_level    = 0;    // 7-bit DAC value ($4011)
+    uint8_t sample_address  = 0;    // raw $4012 value; actual addr = $C000 + A*64
+    uint8_t sample_length   = 0;    // raw $4013 value; actual len  = L*16 + 1
 
-    // bit 6 of $4010
-    bool loop = false;
+    // Status
+    bool    irq_pending     = false;
+    bool    enabled         = false; // $4015 bit 4
 
-    // rate index
-    // rate determines for how many CPU cycles happen between changes in
-    // the output level during automatic delta-encoded playback..
-    uint8_t rate_index = 0;
+    // Memory reader state
+    uint8_t  sample_buffer       = 0;
+    bool     sample_buffer_full  = false;
+    uint16_t current_address     = 0;
+    uint16_t bytes_remaining     = 0;
 
-    // 7 bits of $4011
-    uint8_t output_level = 0;
+    // Output unit state
+    uint16_t timer_counter  = 0;
+    uint8_t  shift_register = 0;
+    uint8_t  bits_remaining = 0;
+    bool     silence        = false;
 
-    // all of $4012 AAAA.AAAA
-    // Sample address = %11AAAAAA.AA000000 = $C000 + (A * 64)
-    uint8_t sample_address = 0;
+    // CPU stall cycles from DMA sample fetches (typically 1-4 cycles)
+    uint8_t  pending_stall_cycles = 0;
 
-    // all of $4013 LLLL.LLLL
-    // Sample length = %LLLL.LLLL0001 = (L * 16) + 1 bytes
-    uint8_t sample_length = 0;
-
-    // rate table
-    // The rate determines for how many CPU cycles happen between changes in the
-    // output level during automatic delta-encoded sample playback. For example,
-    // on NTSC (1.789773 MHz), a rate of 428 gives a frequency of
-    // 1789773/428 Hz = 4181.71 Hz. Inlined to reduce confusion and risk.
-    // NES Dev Wiki has these values doubled because it assumes 1 CPU per APU clock,
-    // but we are clocking our APU for every two CPU clocks already, so we halve the values
-    // here.
-    // see https://www.nesdev.org/wiki/APU_DMC#Pitch_table for full pitch table
-    inline static constexpr uint16_t RATE[16] = {
-        214, // $0
-        190, // $1
-        170, // $2
-        160, // $3
-        143, // $4
-        127, // $5
-        113, // $6
-        107, // $7
-        95, // $8
-        80, // $9
-        71, // $A
-        64, // $B
-        53, // $C
-        42, // $D
-        36, // $E
-        27 // $F
+    // NTSC rate table (in APU ticks; already halved from NES Dev Wiki values).
+    static constexpr uint16_t RATE_TABLE[16] = {
+        214, 190, 170, 160, 143, 127, 113, 107,
+         95,  80,  71,  64,  53,  42,  36,  27
     };
 
-    // memory reader state values
-    // TODO: separate class?
+private:
+    Memory* memory_ = nullptr;
 
-    // The sample buffer either holds a single 8-bit sample byte or is empty. It is filled
-    // by the reader and can only be emptied by the output unit; once loaded with a sample
-    // byte it will be played back when output unit reaches the end of a byte
-    uint8_t sample_buffer = 0;
-
-    // sample buffer either holds a single 8-bit sample byte or is empty
-    bool sample_buffer_full = false;
-
-    // offset into sample
-    uint16_t current_address = 0;
-
-    // how many bytes of the current sample are left to be played
-    uint16_t bytes_remaining = 0;
-
-    // output unit state values
-    // TODO: separate class?
-    // Nothing can interrupt a cycle; every cycle runs to completion before a new cycle is started.
-
-    // countdown timer that reloads from RATE[rate_index]
-    // we decrement timer_counter once per APU tick and never do halving
-    // because our inline table has already been halved.
-    uint16_t timer_counter = 0;
-
-    // holds the current 8 bits loaded from the sample buffer on every output cycle end
-    uint8_t shift_reg = 0;
-
-    // The bits remaining counter is updated whenever a timer outputs a clock regardless
-    // of whether a sample is currently playing. When this counter reaches zero, we say
-    // teh output cycle ends.  The DPCM unit can only transition from silent to playing
-    // at the end of an output cycle. See https://www.nesdev.org/wiki/APU_DMC#Output_unit
-    uint8_t bits_remaining = 0;
-
-    // output_level is not changed when silence is true
-    bool silence = false;
-
-    // write to channel registers
-    void write_register(uint8_t reg, uint8_t value);
-
-    // when a sample is (re)started, the current address is set to the sample address,
-    // and bytes remaining is set to the sample length.
-    void play_sample();
-
-    // attempts to fill sample_buffer if empty and bytes_remaining > 0.
-    // returns true if a fetch occurred.
-    // consumes byte, bumps address and may wrap, may trigger loop, needs to stall CPU somehow.
-    // see https://www.nesdev.org/wiki/APU_DMC#Memory_reader for tricky implementation
-    // guidance.
-    // TODO: improve comment to explain trickiness
     bool fetch_sample_byte();
-
-    // Memory interface for DMC sample reads
-    // DMC needs to read sample bytes from CPU address space ($C000-$FFFF)
-    Memory* memory = nullptr;
-
-    // connect to memory subsystem for DMC sample reads
-    void attach_memory(Memory* m);
-
-    // CPU stall cycles pending from DMC sample fetches
-    // DMC sample fetches cause CPU stalls due to bus contention (typically 1-4 cycles)
-    // check this after each APU step and apply stalls to CPU
-    uint8_t pending_stall_cycles = 0;
-
-    // clock the timer called every APU cycle = every 2 CPU cycles
-    void clock_timer();
-
-    // helper method to handle output operations
     void clock_output_unit();
+    void clock_memory_reader();
 
-    // helper method to handle sample buffer operations
-    // calls fetch_sample_byte() whenever sample buffer is empty and
-    // there are bytes remaining no matter whether output unit is silent
-    void clock_memory_unit();
+    // Compute the CPU address from the raw $4012 value.
+    static uint16_t decode_address(uint8_t raw) {
+        return 0xC000 | (static_cast<uint16_t>(raw) << 6);
+    }
 
-    // get current 7-bit output sample (0-127)
-    uint8_t output() const;
-
-    // reset all dmc state
-    void reset();
+    // Compute the byte count from the raw $4013 value.
+    static uint16_t decode_length(uint8_t raw) {
+        return (static_cast<uint16_t>(raw) << 4) + 1;
+    }
 };
 
-// The main APU class contains all audio channels and the frame counter.
-// Based on https://www.nesdev.org/wiki/APU#Pulse_($4000–$4007)
 
+// The main APU class: all audio channels plus the frame counter.
+// Based on https://www.nesdev.org/wiki/APU
 class APU {
 public:
-
     APU();
 
     void reset();
+
+    // Advance the APU by one CPU cycle.
     void step();
 
-    PulseChannel pulse1{true};   // true = is pulse 1 (affects sweep)
-    PulseChannel pulse2{false};  // false = is pulse 2
-    Triangle triangle;
-    Noise noise;
-    DeltaModulationChannel dmc;
+    // Register interface (address range $4000-$4017)
+    void    write_register(uint16_t address, uint8_t value);
+    uint8_t read_status();   // $4015 read
 
-    //  frame counter
-    uint16_t frame_counter_cycles = 0;  // Cycle counter for frame sequencer
-    uint8_t frame_counter_step = 0;     // Current step (0-3 or 0-4)
-    bool frame_counter_mode = false;    // false = 4-step, true = 5-step
-    bool frame_irq_inhibit = false;     // Inhibit frame counter IRQ
-    bool frame_irq_flag = false;        // Frame IRQ pending
-
-    //  register interface
-    //  writes to these should go through write_register()
-    uint8_t $4000 = 0, $4001 = 0, $4002 = 0, $4003 = 0;  // Pulse 1
-    uint8_t $4004 = 0, $4005 = 0, $4006 = 0, $4007 = 0;  // Pulse 2
-    uint8_t $4008 = 0, $4009 = 0, $400A = 0, $400B = 0;  // Triangle
-    uint8_t $400C = 0, $400D = 0, $400E = 0, $400F = 0;  // Noise
-    uint8_t $4010 = 0, $4011 = 0, $4012 = 0, $4013 = 0;  // DMC
-    uint8_t $4015 = 0;  // Status
-    uint8_t $4017 = 0;  // Frame counter
-
-    // write to APU register
-    void write_register(uint16_t address, uint8_t value);
-
-    // write APU status ($4015)
-    void write_status(uint8_t value);
-
-    // write APU frame counter ($4017)
-    void write_frame_counter(uint8_t value);
-
-    // read APU status ($4015)
-    uint8_t read_status();
-
-    // mixed audio output
+    // Mixed audio output (0.0 – ~1.0)
     float get_output() const;
 
-    // pulse audio output
-    float get_pulse_output() const;
+    // Channels (public for test / debug access)
+    PulseChannel          pulse1{true};
+    PulseChannel          pulse2{false};
+    Triangle              triangle;
+    Noise                 noise;
+    DeltaModulationChannel dmc;
 
-    // triangle-noise-dmc output
-    float get_tnd_output() const;
+    // Frame counter state
+    uint16_t frame_counter_cycles = 0;
+    uint8_t  frame_counter_step   = 0;
+    bool     frame_counter_mode   = false; // false = 4-step, true = 5-step
+    bool     frame_irq_inhibit    = false;
+    bool     frame_irq_flag       = false;
 
 private:
-    // clock frame counter components
+    void write_status(uint8_t value);
+    void write_frame_counter(uint8_t value);
+
     void clock_frame_counter();
-    void clock_quarter_frame();  // envelope
-    void clock_half_frame();     // length counter + sweep
+    void clock_quarter_frame(); // envelopes + triangle linear counter
+    void clock_half_frame();    // length counters + sweep
 
-    // CPU cycle counter for timing frame counter
-    uint64_t cpu_cycle = 0;
+    float get_pulse_output() const;
+    float get_tnd_output() const;
 
-    // surface last write to status for per-channel access
-    uint8_t status_enable = 0;
+    uint64_t cpu_cycle     = 0;
+    uint8_t  status_enable = 0;
 };
 
 } // namespace nes

--- a/src/nes/ROM.cpp
+++ b/src/nes/ROM.cpp
@@ -10,23 +10,18 @@ namespace nes {
     static constexpr std::size_t PRG_BANK_SIZE      = 16 * 1024;
     static constexpr std::size_t CHR_BANK_SIZE      = 8 * 1024;
 
-    // Helper function to read an exact number of bytes from the file stream, returning false if the read fails
-    // Used to simplify error handling when reading the ROM file (cleaner happy path code)
-    // TODO: validate file length before reading (defensive against truncated ROMs)
-    auto read_exact = [&](void* dst, std::size_t size) {
-        f.read(static_cast<char*>(dst), size);
-        return static_cast<bool>(f);
-    };
-
     // Parses the ROM file based on the iNES file format specification: https://www.nesdev.org/wiki/INES
     bool ROM::load_from_file(const char* path) {
         std::ifstream f(path, std::ios::binary);
         if (!f) return false;
 
-        // Open file
-        std::ifstream file(path, std::ios::binary);
-        if (!file) return false;
-    
+        // Helper function to read an exact number of bytes from the file stream, returning false if the read fails
+        // Used to simplify error handling when reading the ROM file (cleaner happy path code)
+        // TODO: validate file length before reading (defensive against truncated ROMs)
+        auto read_exact = [&](void* dst, std::size_t size) {
+            f.read(static_cast<char*>(dst), size);
+            return static_cast<bool>(f);
+        };
 
         // Read header
         std::array<uint8_t, HEADER_SIZE> header{};

--- a/src/nes/apu.cpp
+++ b/src/nes/apu.cpp
@@ -1,1069 +1,794 @@
 #include "nes/apu.hpp"
 #include "nes/mem.hpp"
 
-namespace nes
+namespace nes {
+
+// ============================================================================
+// Envelope
+// ============================================================================
+
+void Envelope::clock()
 {
-    APU::APU() { reset(); }
-
-    // safe for start and reset
-    void APU::reset()
+    // https://www.nesdev.org/wiki/APU_Envelope
+    if (start_flag)
     {
-        frame_counter_step = 0;
-        frame_counter_cycles = 0;
-        status_enable = 0;
-        frame_counter_mode = false;
-        frame_irq_flag = false;
-        cpu_cycle = 0;
+        // Restart: clear flag, reload decay to max, reload divider.
+        start_flag  = false;
+        decay_level = 15;
+        divider     = volume_period;
+        return;
+    }
 
-        // clear status
-        write_register($4015, 0x00);
-
-        pulse1.reset();
-        pulse2.reset();
-        triangle.reset();
-        noise.reset();
-        dmc.reset();
-    };
-
-    // https://www.nesdev.org/wiki/APU_Frame_Counter
-    // We only support NTSC timings
-    // From https://www.nesdev.org/wiki/APU_Frame_Counter
-    // The frame counter generates clocks for the envelope, length counter, and
-    // sweep units. It can operate in two modes defined by $4017 depending how it is configured.
-    // It may optionally issue an IRQ on the last tick of the 4-step sequence.
-    // The following diagram illustrates the two modes, selected by bit 7 of $4017:
-    //    mode 0:    mode 1:       function
-    //    -  ---  -
-    //     - - - f    - - - - -    IRQ (if bit 6 is clear)
-    //     - l - l    - l - - l    Length counter and sweep
-    //     e e e e    e e e - e    Envelope and linear counter
-    //
-    // 4-step mode (mode bit = 0):
-    //   Step 1: Clock envelope
-    //   Step 2: Clock envelope + length/sweep
-    //   Step 3: Clock envelope
-    //   Step 4: Clock envelope + length/sweep, set IRQ flag
-    //   (Then loops back to step 1)
-    //
-    // 5-step mode (mode bit = 1):
-    //   Step 1: Clock envelope
-    //   Step 2: Clock envelope + length/sweep
-    //   Step 3: Clock envelope
-    //   Step 4: Clock envelope + length/sweep
-    //   Step 5: (nothing)
-    //   (Then loops back to step 1)
-    //   In this mode, the frame interrupt flag is never set.
-    //
-    // Note that the frame counter is not exactly synchronized with the PPU NMI;
-    // it runs independently at a consistent rate which is approximately 240Hz (NTSC) in 4-step mode.
-    // Some games (e.g. The Legend of Zelda, Super Mario Bros.) manually synchronize it by
-    // writing $C0 or $FF to $4017 once per frame.
-    void APU::clock_frame_counter()
+    // Normal tick: clock the divider.
+    if (divider != 0)
     {
-        frame_counter_cycles++;
+        divider--;
+        return;
+    }
 
-        if (frame_counter_mode) // 5-step mode
+    // Divider hit 0 — reload it and clock the decay counter.
+    divider = volume_period;
+
+    if (decay_level != 0)
+        decay_level--;
+    else if (loop_flag)
+        decay_level = 15;
+}
+
+uint8_t Envelope::output() const
+{
+    return constant_volume_flag ? volume_period : decay_level;
+}
+
+void Envelope::reset()
+{
+    start_flag  = false;
+    decay_level = 0;
+    divider     = 0;
+    // Configuration fields (loop_flag, constant_volume_flag, volume_period)
+    // are owned by the parent channel and intentionally not cleared here.
+}
+
+// ============================================================================
+// LengthCounter
+// ============================================================================
+
+const uint8_t LengthCounter::TABLE[32] = {
+     10, 254,  20,   2,  40,   4,  80,   6,
+    160,   8,  60,  10,  14,  12,  26,  14,
+     12,  16,  24,  18,  48,  20,  96,  22,
+    192,  24,  72,  26,  16,  28,  32,  30
+};
+
+void LengthCounter::load(uint8_t table_index)
+{
+    counter = TABLE[table_index & 0x1F];
+}
+
+void LengthCounter::clock()
+{
+    if (counter != 0 && !halt)
+        counter--;
+}
+
+// ============================================================================
+// SweepUnit
+// ============================================================================
+
+uint16_t SweepUnit::calculate_target_period(uint16_t current_period) const
+{
+    const uint16_t change = current_period >> shift;
+
+    if (!negate)
+        return current_period + change;
+
+    // Pulse 1: ones'-complement negation (subtract change + 1)
+    // Pulse 2: twos'-complement negation (subtract change)
+    const uint16_t negated = is_channel1 ? (change + 1) : change;
+    return (current_period >= negated) ? (current_period - negated) : 0;
+}
+
+bool SweepUnit::is_muting(uint16_t target_period)
+{
+    return target_period > 0x7FF;
+}
+
+bool SweepUnit::clock(uint16_t& timer_period)
+{
+    bool period_updated = false;
+
+    if (divider == 0 || reload_flag)
+    {
+        // When divider expires with sweep active, update the period.
+        if (divider == 0 && enabled && shift != 0)
         {
-            switch (frame_counter_cycles)
+            const uint16_t target = calculate_target_period(timer_period);
+            if (!is_muting(target))
             {
-                case 3728: clock_quarter_frame(); break;
-                case 7456: clock_quarter_frame(); clock_half_frame(); break;
-                case 11185: clock_quarter_frame(); break;
-                case 14914: break; // silent step. ssssshhh...
-                case 18640: clock_quarter_frame(); clock_half_frame(); frame_counter_cycles = 0; break;
-                // In this mode, the frame interrupt flag is never set.
+                timer_period   = target;
+                period_updated = true;
             }
         }
-        else // 4-step  mode
-        {
-            switch (frame_counter_cycles)
-            {
-                case 3728: clock_quarter_frame(); break;
-                case 7456: clock_quarter_frame(); clock_half_frame(); break;
-                case 11185: clock_quarter_frame(); break;
-                case 14914:
-                    {
-                        clock_quarter_frame();
-                        clock_half_frame();
-
-                        // frame interrupt flag gets set if interrupt inhibit is clear
-                        if (!frame_irq_inhibit) frame_irq_flag = true;
-
-                        frame_counter_cycles = 0;
-                        break;
-                    }
-            }
-        }
-    }
-
-    // length counters and sweep units only on half frame
-    // https://www.nesdev.org/wiki/APU_Frame_Counter
-    void APU::clock_half_frame()
-    {
-        pulse1.clock_length_and_sweep();
-        pulse2.clock_length_and_sweep();
-    }
-
-    // envelopes and linear counters only on quarter frame
-    // https://www.nesdev.org/wiki/APU_Frame_Counter
-    void APU::clock_quarter_frame()
-    {
-        pulse1.clock_envelope();
-        pulse2.clock_envelope();
-        noise.clock_envelope();
-        triangle.clock_linear_counter();
-    }
-
-    // see https://www.nesdev.org/wiki/APU_Mixer
-    // output = pulse_out + tnd_out
-    // this is NOT efficient, but it is highly accurate and should be fast
-    // on modern hardware, as required by NES-EMU specification
-    // TODO: optionally consider implementing high- and low-pass filters
-    float APU::get_output() const
-    {
-        return get_pulse_output() + get_tnd_output();
-    }
-
-    // pulse audio output
-    //                          95.88
-    // pulse_out = ------------------------------------
-    //              (8128 / (pulse1 + pulse2)) + 100
-    float APU::get_pulse_output() const
-    {
-        const float pulse_sum = pulse2.output() + pulse1.output(); // NOLINT(*-narrowing-conversions)
-        if (pulse_sum > 0.0f)
-            return 95.88f / ((8128.0f / pulse_sum) + 100.0f);
-        return 0.0f;
-    }
-
-    // triangle-noise-dmc output formula from https://www.nesdev.org/wiki/APU_Mixer
-    //
-    //                              159.79
-    // tnd_out = -------------------------------------------------------------
-    //                                  1
-    //           ----------------------------------------------------- + 100
-    //           (triangle / 8227) + (noise / 12241) + (dmc / 22638)
-    float APU:: get_tnd_output() const
-    {
-        const float t = triangle.output();
-        const float n = noise.output();
-        const float d = dmc.output();
-        const float tnd_sum = (t / 8227.0f) + (n / 12241.0f) + (d /22638.0f);
-        if (tnd_sum > 0.0f)
-            return 159.79f / ((1.0f / tnd_sum) + 100.0f);
-        return 0.0f;
-    }
-
-    // From https://www.nesdev.org/wiki/APU#Status_($4015)
-    // write APU status ($4015). writing zero silences NT21; dmc finishes sample before silence
-    // 4-bits: ---D NT21 	Enable DMC (D), noise (N), triangle (T), and pulse channels (2/1)
-    void APU::write_status(uint8_t value)
-    {
-        status_enable = value & 0x1F; // mask to keep lower 5 bits
-
-        // clear length counter to silence NT21
-        // Pulse 1
-        pulse1.enabled = (status_enable & 0x01) != 0;
-        if (!pulse1.enabled)
-            pulse1.length_counter.clear();
-
-        // Pulse 2
-        pulse2.enabled = (status_enable & 0x02) != 0;
-        if (!pulse2.enabled)
-            pulse2.length_counter.clear();
-
-        // Triangle
-        triangle.enabled = (status_enable & 0x04) != 0;
-        if (!triangle.enabled)
-            triangle.length_counter.clear();
-
-        // Noise (no enabled flag)
-        if ((status_enable & 0x08) == 0)
-            noise.length_counter.clear();
-
-        // DMC (must be symmetric: enable AND disable)
-        dmc.enabled = (status_enable & 0x10) != 0;
-
-        // "Writing to this register clears the DMC interrupt flag."
-        dmc.irq_pending = false;
-    }
-
-    // From https://www.nesdev.org/wiki/APU_Frame_Counter
-    // $4017 	MI-- ---- 	Mode (M, 0 = 4-step, 1 = 5-step), IRQ inhibit flag (I)
-    // write APU frame counter ($4017)
-    void APU::write_frame_counter(uint8_t value)
-    {
-        frame_irq_inhibit = (value & 0x40) != 0;
-
-        // Sequencer mode: 0 selects 4-step sequence, 1 selects 5-step sequence
-        frame_counter_mode = (value & 0x80) != 0;
-
-        // "If interrupt inhibit flag set, the frame interrupt flag is cleared,
-        // otherwise it is unaffected."
-        if (frame_irq_inhibit) frame_irq_flag = false;
-
-        // reset sequencer after clearing flag
-        frame_counter_step = 0;
-        frame_counter_cycles = 0;
-
-        // side effect: if mode is set then both quarter frame and half frame generated
-        if (frame_counter_mode)
-        {
-            clock_quarter_frame();
-            clock_half_frame();
-        }
-    }
-
-    // From https://www.nesdev.org/wiki/APU#Status_($4015)
-    // $4015 read IF-D NT21
-    uint8_t APU::read_status()
-    {
-        uint8_t status = 0;
-
-        // bits 0-3: channels are considered enabled if its length counter is non-zero
-        // "length counter > 0 (N/T/2/1)"
-        if (pulse1.length_counter.counter > 0) status |= 0x01;
-        if (pulse2.length_counter.counter > 0) status |= 0x02;
-        if (triangle.length_counter.counter > 0) status |= 0x04;
-        if (noise.length_counter.counter > 0) status |= 0x08;
-
-        // bit 4: D will read as 1 if the DMC bytes remaining is more than 0.
-        if (dmc.bytes_remaining > 0) status |= 0x10;
-
-        // bit 5 is open bus so never |= 0x20.
-        // Because the external bus is disconnected when reading $4015,
-        // the open bus value comes from the last cycle that did not read $4015,
-
-        // bit 6 frame interrupt (F)
-        if (frame_irq_flag) status |= 0x40;
-
-        // bit 7: the tricky bit-- DMC interrupt (I) is irq_pending (not irq_enable)
-        if (dmc.irq_pending) status |= 0x80;
-
-        // reading $4015 clear frame interrupt and the DMC interrupt
-        frame_irq_flag = false;
-        dmc.irq_pending = false;
-
-        // But NES Dev says: If an interrupt flag was
-        // set at the same moment of the read, it will read back as 1
-        // but it will not be cleared. We do not emulate this behavior
-        // which nesttest ROM says is fine.
-        // TODO: determine if this level of APU/CPU sync is necessary
-
-        return status;
-    }
-
-    // Invariant: always call write_register() before step() in CPU cycle, and only once per cycle for each
-    void APU::step()
-    {
-        // TODO: verify order of operations herein
-        cpu_cycle++;
-        clock_frame_counter();
-
-        // clock all the channel timers.
-        // triangle ticks on every CPU cycle
-        triangle.clock_timer();
-
-        // and others tick on every other CPU cycle
-        if (!(cpu_cycle & 1)) // if not odd
-        {
-            pulse1.clock_timer();
-            pulse2.clock_timer();
-            noise.clock_timer();
-            dmc.clock_timer();
-        }
-    }
-
-    // from https://www.nesdev.org/wiki/APU_registers
-    void APU::write_register(uint16_t address, uint8_t value)
-    {
-        // don't trust inputs in exposed interfaces
-        if (address < 0x4000 || address > 0x4017)
-            return;
-
-        switch (address)
-        {
-        case 0x4015: write_status(value); return;
-        case 0x4017: write_frame_counter(value); return;
-
-        // 0x4000 - 0x4003 pulse 1
-        case 0x4000:
-        case 0x4001:
-        case 0x4002:
-        case 0x4003: pulse1.write_register(address - 0x4000, value); return;
-
-        // 0x4004 - 0x4007 pulse 2
-        case 0x4004:
-        case 0x4005:
-        case 0x4006:
-        case 0x4007: pulse2.write_register(address - 0x4004, value); return;
-
-        // 0x4008 - 0x400B triangle
-        case 0x4008:
-        case 0x4009:    // not implemented in triangle
-        case 0x400A:
-        case 0x400B: triangle.write_register(address - 0x4008, value); return;
-
-        // 0x400C - 0x400F noise
-        case 0x400C:
-        case 0x400D:    // not implemented in noise
-        case 0x400E:
-        case 0x400F: noise.write_register(address - 0x400C, value); return;
-
-        // 0x4010 - 0x4013 dmc
-        case 0x4010:
-        case 0x4011:
-        case 0x4012:
-        case 0x4013: dmc.write_register(address - 0x4010, value); return;
-        default: return;
-        }
-    }
-
-    // see https://www.nesdev.org/wiki/APU_Pulse
-    PulseChannel::PulseChannel(bool is_pulse1) { sweep.is_pulse1 = is_pulse1; }
-
-    void PulseChannel::clock_envelope() { envelope.clock(); }
-
-    void PulseChannel::clock_length_and_sweep()
-    {
-        length_counter.clock();
-        sweep.clock(timer_period);
-    }
-
-    void PulseChannel::clock_timer()
-    {
-        // decrementing until we're done means playing the current note for the timer_period
-        // then advancing to the next step in the waveform sequence and playing that note
-        // for the timer period
-        if (timer_counter == 0)
-        {
-            // sequencer wraps 0..7
-            sequencer_position = (sequencer_position + 1) & 0x07;
-            timer_counter = timer_period;
-        }
-        else
-        {
-            timer_counter--;
-        }
-    }
-
-    // structured for our incrementing sequencer
-    const uint8_t PulseChannel::DUTY_TABLE[4][8] =
-    {
-        // 0  1  2  3  4  5  6  7   <- sequencer_position
-        { 0, 1, 0, 0, 0, 0, 0, 0 }, // 12.5%
-        { 0, 1, 1, 0, 0, 0, 0, 0 }, // 25%
-        { 0, 1, 1, 1, 1, 0, 0, 0 }, // 50%
-        { 1, 0, 0, 1, 1, 1, 1, 1 }  // 75%
-    };
-
-    // See https://www.nesdev.org/wiki/APU_Pulse#Pulse_channel_output_to_mixer
-    // relies on envelope output unless silenced for one of several reasons
-    // TODO: optimize; also consider Blaarg Smooth Vibrato technique to eliminate "pops" on square channels
-    uint8_t PulseChannel::output() const
-    {
-        // there are several ways to mute
-        if (!enabled
-            || length_counter.counter == 0
-            || timer_period < 8
-            || !DUTY_TABLE[duty_mode][sequencer_position]
-            || SweepUnit::is_muting(sweep.calculate_target_period(timer_period)))
-            return 0;
-        return envelope.output();
-    }
-
-    // safe for start and reset
-    void PulseChannel::reset()
-    {
-        enabled = false;
-        timer_counter = 0;
-        timer_period = 0;
-        duty_mode = 0;
-        sequencer_position = 0;
-
-        envelope.reset();
-        length_counter.reset();
-        sweep.reset();
-    }
-
-
-    // From https://www.nesdev.org/wiki/APU_Pulse#Registers
-    void PulseChannel::write_register(uint8_t reg, uint8_t value)
-    {
-        // we always pass "address - $4000" or "address - $4003" or similar
-        // so normalizes reg to 0..3
-        switch (reg & 0x03)
-        {
-        // $4000/$4004
-        case 0:
-            {
-                // bits 3-0 envelope period
-                envelope.volume_period = value & 0x0F;
-
-                // bit 4 constant volume (1) and envelope decay (0)
-                envelope.constant_volume_flag = (value & 0x10) != 0;
-
-                // see https://www.nesdev.org/wiki/APU_Envelope
-                // bit 5 --L- ---- 	APU Length Counter halt flag/envelope loop flag
-                bool halt_or_loop = (value & 0x20) != 0;
-                length_counter.halt = halt_or_loop;
-                envelope.loop_flag = halt_or_loop;
-
-                // bits 7-6 duty_mode 0..3
-                // shift and isolate the 2 bits into duty_mode 0..3 values
-                duty_mode = (value >> 6) & 0x03;
-
-                // side effects duty cycle is changed but sequencer position unchanged
-                break;
-            }
-
-        // $4001/$4005
-        case 1:
-            {
-                // see https://www.nesdev.org/wiki/APU_Sweep
-                // EPPP.NSSS
-                // bit 7 	E--- ---- 	Enabled flag
-                sweep.enabled = (value & 0x80) != 0;
-
-                // bits 6-4 	-PPP ---- 	The divider's period is P + 1 half-frames
-                sweep.period  = (value >> 4) & 0x07;
-
-                // bit 3 	---- N--- 	Negate flag
-                // 0: add to period, sweeping toward lower frequencies
-                // 1: subtract from period, sweeping toward higher frequencies
-                sweep.negate  = (value & 0x08) != 0;
-
-                // bits 2-0 	---- -SSS 	Shift count (number of bits).
-                // If SSS is 0, then behaves like E=0.
-                sweep.shift   = value & 0x07;
-
-                // Side effects 	Sets the reload flag
-                sweep.reload_flag = true;
-
-                break;
-            }
-
-        // $4002/$4006
-        case 2:
-            {
-                // timer low 8 bits
-                // clear
-                timer_period &= 0x0700;
-
-                // set
-                timer_period |= value;
-
-                break;
-            }
-        // $4003/$4007
-        case 3:
-            {
-                // bits 2-0 timer high 3 bits
-                // clear high bits
-                timer_period &= 0x00FF;
-
-                // set high 3 bits
-                timer_period |= (value & 0x07) << 8;
-
-                // bits 7-3 length index 0..31
-                // see https://www.nesdev.org/wiki/APU_Length_Counter
-                // When the enabled bit is cleared (via $4015), the length counter is forced to 0 and cannot be changed
-                // until enabled is set again (the length counter's previous value is lost).
-                // LLLL L--- >> 3 -> ---L LLLL &  0x1F -> 0..31 so
-                length_counter.load((value >> 3) & 0x1F);
-
-                // side effects - sequencer and envelope restarted, phase is reset
-                envelope.start_flag = true;
-                sequencer_position = 0;
-                timer_counter = timer_period;
-
-                break;
-            }
-        }
-    }
-
-    // all comments below from https://www.nesdev.org/wiki/APU_Envelope
-    void Envelope::clock()
-    {
-        // if the start flag is clear,
-        // the divider is clocked
-        if (!start_flag)
-        {
-            if (divider != 0) {divider--; }
-            else // When the divider is clocked while at 0
-            {
-                // it is loaded with V
-                divider = volume_period;
-
-                // and clocks the decay level counter.
-                // Then one of two actions occurs: If the counter is non-zero, it is decremented,
-                if (decay_level != 0) {decay_level--; }
-                else
-                {
-                    // otherwise if the loop flag is set, the decay level counter is loaded with 15.
-                    // take it from the top, maestro
-                    if (loop_flag) { decay_level = 15; }
-                }
-            }
-
-        }
-        else // otherwise
-        {
-            // the start flag is cleared,
-            start_flag = false;
-
-            // the decay level counter is loaded with 15,
-            decay_level = 15;
-
-            // and the divider's period is immediately reloaded.
-            divider = volume_period;
-        }
-    }
-
-    // from https://www.nesdev.org/wiki/APU_Envelope
-    // The envelope unit's volume output depends on the constant volume flag:
-    // if set, the envelope parameter directly sets the volume, otherwise the decay level is the current volume.
-    // The constant volume flag has no effect besides selecting the volume source;
-    // the decay level will still be updated when constant volume is selected
-    // so all we need to return is decay_level which is already 0..15
-    uint8_t Envelope::output() const { return decay_level; }
-
-    void Envelope::reset()
-    {
-        start_flag = false;
-        decay_level = 0;
-        divider = 0;
-        // do not reset these 3, they come from channel registers
-        //  loop_flag
-        //  constant_volume_flag
-        //  volume_period
-    }
-
-    // static lookup table for length counter values
-    // If the enabled flag is set, the length counter is
-    // loaded with entry L of the length table:
-    const uint8_t LengthCounter::LENGTH_TABLE[32] =
-        {10,254, 20,  2, 40,  4, 80,  6,
-        160,  8, 60, 10, 14, 12, 26, 14,
-        12, 16, 24, 18, 48, 20, 96, 22,
-        192, 24, 72, 26, 16, 28, 32, 30};
-
-    // see https://www.nesdev.org/wiki/APU_Length_Counter#Clocking
-    // The length counter provides automatic duration control for the NES APU waveform channels.
-    void LengthCounter::clock()
-    {
-        //When clocked by the frame counter, the length counter is decremented except when:
-        // The length counter is 0, or
-        // The halt flag is set
-        if (counter != 0 && !halt) {  counter--; }
-    }
-
-    // see https://www.nesdev.org/wiki/APU_Length_Counter
-    // Once loaded with a value, the length counter can optionally count down
-    // Once it reaches zero, the corresponding channel is silenced.
-    void LengthCounter::load(uint8_t index) { counter = LENGTH_TABLE[index & 0x1F]; }
-
-    // do not reset halt. it comes from channel registers
-    void LengthCounter::reset()  { counter = 0; }
-
-    // see https://www.nesdev.org/wiki/APU_Sweep
-    bool SweepUnit::clock(uint16_t& timer_period)
-    {
-        if (divider != 0)
-        {
-            divider--;
-        }
-        else
-        {
-            // https://www.nesdev.org/wiki/APU_Sweep#Updating_the_period
-            // reload the divider's period as normal
-            divider = period;
-
-            if (enabled == true && shift != 0)
-            {
-                uint16_t target_period = calculate_target_period(timer_period);
-
-                // case 1.1. pulse's period is set to the target period
-                if (!is_muting(target_period))
-                {
-                    timer_period = target_period;
-                    return true;
-                }
-
-            }
-        }
-        return false; // case 1.2. is already fully addressed so the period was not changed
-    }
-
-    // from https://www.nesdev.org/wiki/APU_Sweep#Calculating_the_target_period
-    // The sweep unit continuously calculates each pulse channel's target period
-    uint16_t SweepUnit::calculate_target_period(uint16_t current_period) const
-    {
-        // A barrel shifter shifts the pulse channel's 11-bit raw timer period right by the shift count,
-        // producing the change amount.
-        // If the negate flag is true, the change amount is made negative, so pitch sounds higher
-        if (negate) {
-            // one's-complement quirk
-            if (is_pulse1) return current_period - (current_period >> shift) - 1;
-            // pulse 2 is merely the difference
-            else return current_period - (current_period >> shift);
-        }
-        // negate is false so change amount get added -- period gets longer, so pitch sounds lower
-        else return current_period + (current_period >> shift);
-    }
-
-    // from https://www.nesdev.org/wiki/APU_Sweep#Muting
-    // Two conditions cause the sweep unit to mute the channel until the condition ends:
-    // If the current period is less than 8, the sweep unit mutes the channel. (We check this in PulseChannel.output()).
-    // If at any time the target period is greater than $7FF, the sweep unit mutes the channel.
-    bool SweepUnit::is_muting(uint16_t current_period)
-    {
-        return current_period > 0x7FF;
-    }
-
-    // don't reset is_pulse1 it doesn't come from channel registers but it defines the channel itself.
-    void SweepUnit::reset()
-    {
-        enabled = false;
-        period = 0;
-        negate = false;
-        shift = 0;
+        divider     = period;
         reload_flag = false;
-        divider = 0;
     }
-
-    // The sequencer sends the following looping 32-step sequence of values to the mixer:
-    const uint8_t Triangle::SEQUENCER_TABLE[32] = {
-        15, 14, 13, 12, 11, 10, 9, 8,
-        7, 6, 5, 4, 3, 2, 1, 0,
-        1, 2, 3, 4, 5, 6, 7,8,
-        10, 11, 12, 13, 14, 15 };
-
-
-    // see https://www.nesdev.org/wiki/APU_Triangle
-    void Triangle::reset()
+    else
     {
-        linear_counter = 0;
-        linear_reload_flag = false;
-        timer_counter = 0;
-        sequencer_step = 0;
-        control_flag = false;
-        counter_reload_value = 0;
-        timer_period = 0;
-        enabled = false;
-        length_counter.reset();
+        divider--;
     }
 
-    // When the frame counter generates a linear counter clock, the following actions occur in order:
-    void Triangle::clock_linear_counter()
+    return period_updated;
+}
+
+void SweepUnit::reset()
+{
+    enabled     = false;
+    period      = 0;
+    negate      = false;
+    shift       = 0;
+    reload_flag = false;
+    divider     = 0;
+    // is_channel1 is structural identity — never reset.
+}
+
+// ============================================================================
+// PulseChannel
+// ============================================================================
+
+const uint8_t PulseChannel::DUTY_TABLE[4][8] = {
+    //  0  1  2  3  4  5  6  7
+    {  0, 1, 0, 0, 0, 0, 0, 0 }, // 12.5%
+    {  0, 1, 1, 0, 0, 0, 0, 0 }, // 25%
+    {  0, 1, 1, 1, 1, 0, 0, 0 }, // 50%
+    {  1, 0, 0, 1, 1, 1, 1, 1 }, // 75% (inverted 25%)
+};
+
+PulseChannel::PulseChannel(bool is_channel1)
+{
+    sweep.is_channel1 = is_channel1;
+}
+
+void PulseChannel::write_register(uint8_t reg, uint8_t value)
+{
+    switch (reg & 0x03)
     {
-        // If the linear counter reload flag is set, the linear counter is reloaded with the counter reload value,
-        if (linear_reload_flag) { linear_counter = counter_reload_value; }
-        // otherwise if the linear counter is non-zero, it is decremented.
-        else if (linear_counter != 0) { linear_counter--; }
-
-        // If the control flag is clear (aka linear counter halt flag), the linear counter reload flag is cleared.
-        if (!control_flag) { linear_reload_flag = false; }
-
-        // Note that the reload flag is not cleared unless the control flag is also clear, so when both are already
-        // set a value written to $4008 will be reloaded at the next linear counter clock.
-    }
-
-    // see https://www.nesdev.org/wiki/APU_Triangle
-    void Triangle::clock_timer()
+    case 0: // $4000/$4004  DDLC VVVV
     {
-        // keep counting down until 0
-        if (timer_counter != 0) { timer_counter--; }
-        else
-        {
-            // reload the counter
-            timer_counter = timer_period;
-
-            // if not silenced, step the sequencer in a clamped 0..31 way
-            // this is interesting because when you un-silence Triangle,
-            // it just picks up where you last heard a note. Silence is more
-            // like Pause.
-            if (linear_counter > 0 && length_counter.counter > 0)
-                sequencer_step = (sequencer_step + 1) & 0x1F;
-        }
+        duty_mode                    = (value >> 6) & 0x03;
+        const bool halt_or_loop      = (value & 0x20) != 0;
+        length_counter.halt          = halt_or_loop;
+        envelope.loop_flag           = halt_or_loop;
+        envelope.constant_volume_flag = (value & 0x10) != 0;
+        envelope.volume_period       = value & 0x0F;
+        break;
     }
-
-    // when not silenced, Triangle outputs whatever 0..15 value is currently indexed
-    // by sequencer_step
-    uint8_t Triangle::output() const
+    case 1: // $4001/$4005  EPPP NSSS
     {
-        if (!enabled || length_counter.counter == 0 || linear_counter == 0)
-            return 0;
-
-        return SEQUENCER_TABLE[sequencer_step];
+        sweep.enabled     = (value & 0x80) != 0;
+        sweep.period      = (value >> 4) & 0x07;
+        sweep.negate      = (value & 0x08) != 0;
+        sweep.shift       = value & 0x07;
+        sweep.reload_flag = true;
+        break;
     }
-
-    void Triangle::write_register(uint8_t reg, uint8_t value)
+    case 2: // $4002/$4006  TTTT TTTT  (timer low 8 bits)
     {
-        // $4008 - $400B, but $4009 is unused
-        // so normalizes reg to 0..3
-        switch (reg & 0x03)
-        {
-        // $4008
-        case 0:
-            {
-                // bit 7 control flag aka length counter halt flag 0..3
-                // shift and isolate the 2 bits into duty_mode 0..3 values
-                control_flag = (value >> 7) & 0x01;
-
-                // bits 6-0 	-RRR RRRR 	Counter reload value
-                counter_reload_value = (value & 0x7F);
-
-                // side effects duty cycle is changed but sequencer position unchanged
-                break;
-            }
-
-            // $4009
-        case 1:
-            {
-                // no-op
-                break;
-            }
-
-            // $400A
-        case 2:
-            {
-                // just like PulseChannel
-                // timer low 8 bits
-                // clear
-                timer_period &= 0x0700;
-
-                // set
-                timer_period |= value;
-
-                break;
-            }
-            // $400B
-        case 3:
-            {
-                // just like PuleChannel
-
-                // bits 2-0 timer high 3 bits
-                // clear high bits
-                timer_period &= 0x00FF;
-
-                // set high 3 bits
-                timer_period |= (value & 0x07) << 8;
-
-                // bits 7-3 length index 0..31
-                // see https://www.nesdev.org/wiki/APU_Length_Counter
-                // When the enabled bit is cleared (via $4015), the length counter is forced to 0 and cannot be changed
-                // until enabled is set again (the length counter's previous value is lost).
-                // LLLL L--- >> 3 -> ---L LLLL &  0x1F -> 0..31 so
-                length_counter.load((value >> 3) & 0x1F);
-
-                // Side effects 	Sets the linear counter reload flag
-                linear_reload_flag = true;
-
-                break;
-            }
-        }
+        timer_period = (timer_period & 0x0700) | value;
+        break;
     }
-
-    void Noise::clock_envelope()
+    case 3: // $4003/$4007  LLLL LTTT  (length load + timer high 3 bits)
     {
-        envelope.clock();
+        timer_period = (timer_period & 0x00FF) | (static_cast<uint16_t>(value & 0x07) << 8);
+        length_counter.load((value >> 3) & 0x1F);
+
+        // Side effects: restart sequencer and envelope
+        sequencer_position = 0;
+        timer_counter      = timer_period;
+        envelope.start_flag = true;
+        break;
     }
-
-    void Noise::clock_timer()
-    {
-        if (timer_counter == 0)
-        {
-            // reload from tick table
-            timer_counter = TIMER_PERIOD_IN_APU_TICKS[timer_period_index];
-            clock_shift_register();
-        }
-        else
-        {
-            // continue to count down
-            timer_counter--;
-        }
-    }
-
-    uint8_t Noise::output() const
-    {
-        // determine if channel is active or silenced
-        if ((shift_register_state & 0x01) || length_counter.counter == 0)
-        {
-            return 0;               // silenced immediately
-        }
-
-        return envelope.output();   // active
-    }
-
-    void Noise::write_register(uint8_t reg, uint8_t value)
-    {
-        switch (reg)
-        {
-            case 0:         // $400C    (envelope control)
-                // mask flags:
-                length_counter_halt = (value & 0x20) != 0;          // halt loop
-                constant_volume_flag = (value & 0x10) != 0;         // constant (1 = fixed, 0 = fading)
-                volume_envelope_divider_period = (value & 0x0F);    // volume
-
-                // envelope updated based on flags:
-                envelope.loop_flag = length_counter_halt;
-                envelope.constant_volume_flag = constant_volume_flag;
-                envelope.volume_period = volume_envelope_divider_period;
-
-                break;
-            
-            // $400D    (unused)
-
-            case 2:         // $400E    (frequency and mode)
-                // mask flags:
-                mode_flag = (value & 0x80) != 0;        // length of sequence (1 = short, 0 = long)
-                timer_period_index = (value & 0x0F);    // volume
-
-                // timer reload happens elsewhere (clock_timer)
-
-                break;
-            
-            case 3:         // $400F    (length and trigger)
-                // sound length
-                length_counter.load(value >> 3);    // >> 3 shifts to isolate the top 5 bits of the byte
-
-                // poke the envelope
-                envelope.start_flag = true;         // true resets internal decay
-
-                break;
-        }
-    }
-
-    void Noise::clock_shift_register()
-    {
-        // calculate linear feedback shift:
-        uint16_t feedback_bit = mode_flag ? 6 : 1;      // 6 = short, 1 = long
-        // compare the two bits and store in feedback (1 = different, 0 = same)
-        uint16_t feedback     = (shift_register_state & 0x01) ^
-                                ((shift_register_state >> feedback_bit) & 0x01);
-        
-        // shift right by one:
-        shift_register_state >>= 1;
-
-        // set bit 14 to calculated feedback:
-        shift_register_state |= (feedback << 14);
-    }
-    
-    void Noise::reset()
-    {
-        // reset all defined noise class values back to the defaults defined in apu.hpp
-        length_counter_halt = false;
-        constant_volume_flag = false;
-        volume_envelope_divider_period = 0;
-        mode_flag = false;
-        timer_period_index = 0;
-        timer_counter = 0;
-        shift_register_state = 1;
-
-        // noise synchronisation upon reset
-        envelope.reset();
-        length_counter.reset();
-    }
-
-    uint8_t DeltaModulationChannel::output() const
-    {
-        // provide a single, 7-bit value to the mixer:
-        return output_level;
-    }
-
-    void DeltaModulationChannel::clock_timer()
-    {  
-        // check if timer has run out:
-        if (timer_counter == 0) 
-        {
-            // reload if timer is done
-            timer_counter = RATE[rate_index];
-            clock_output_unit();
-        }
-        else
-        {
-            // coninue counting down if not
-            timer_counter--;
-        }
-    }
-
-    void DeltaModulationChannel::write_register(uint8_t reg, uint8_t value)
-    {
-        switch (reg) {
-            case 0:         // $4010    (behaviour and speed)
-                // mask flags:
-                irq_enable = (value & 0x80);    // interrupt
-                loop = (value & 0x40);          // loop (self explanitory)
-                rate_index = (value & 0x0F);    // pitch
-
-                // irq cleanup
-                if (!irq_enable)
-                {
-                    irq_pending = false;        // clears pending upon disable
-                }
-
-                break;
-
-            case 1:         // $4011    (direct load)
-                // mask flag:
-                output_level = (value & 0x7F);  // bypass "delta" logic
-
-                break;
-
-            case 2:         // $4012    (sample address)
-                // point to memory location of audio data:
-                sample_address = value;         // math done elsewhere
-
-                break;
-
-            case 3:         // $4013    (sample length)
-                // determine how many bytes are read before end (or loop):
-                sample_length = value;         // math done elsewhere
-
-                break;
-        }
-    }
-
-    void DeltaModulationChannel::attach_memory(Memory* m)
-    {
-        // plug in memory:
-        memory = m;
-    }
-
-    void DeltaModulationChannel::clock_memory_unit()
-    {
-        // check if buffer already has a byte anb if current sample is finished:
-        if (!sample_buffer_full && bytes_remaining > 0)
-        {
-            // fetch new byte:
-            fetch_sample_byte();
-        }
-    }
-
-    void DeltaModulationChannel::clock_output_unit()
-    {
-        // check if current byte is done:
-        if (bits_remaining == 0)
-        {
-            // set counter for next byte:
-            bits_remaining = 8;
-
-            // check if buffer is empty:
-            if (!sample_buffer_full)
-            {
-                silence = true;                 // wait for next sample
-            }
-            else
-            {
-                silence = false;                // play sample
-                shift_reg = sample_buffer;      // move byte into register
-                sample_buffer_full  = false;    // mark that sample is playing
-            }
-        }
-
-        // check if able to play sample:
-        if (!silence)
-        {
-            // check bit 0 (1 = +2, 0 = -2)
-            if (shift_reg & 0x01)
-            {
-                // check if within edge:
-                if (output_level <= 125)
-                {
-                    output_level += 2;
-                }
-            }
-            else
-            {
-                // check if within edge:
-                if (output_level >= 2)
-                {
-                    output_level -= 2;
-                }
-            }
-
-            // move to next bit:
-            shift_reg >>= 1;
-        }
-
-        // count down bit "timer":
-        bits_remaining--;
-    }
-
-    bool DeltaModulationChannel::fetch_sample_byte()
-    {
-        if (memory == nullptr)
-        {
-            return false;
-        }
-
-        // data fetch:
-        sample_buffer = memory->read(current_address);  // grabs next byte to read and store it
-        sample_buffer_full = true;                      // indicates that a byte is waiting
-
-        // handle wrap-around:
-        current_address++;              // increment bit
-        if (current_address == 0)       // checks if address wrapped back to $0000
-        {
-            current_address = 0x8000;   // resets position to $8000
-        }
-
-        // 
-        bytes_remaining--;              // counts down bit "timer"
-        if (bytes_remaining == 0)       // checks if counter is done
-        {
-            // if loop is on:
-            if (loop) 
-            {
-                // restart byte:
-                current_address = 0xC000 | (uint16_t(sample_address) << 6);
-                bytes_remaining = (uint16_t(sample_length) << 4) + 1;
-            }
-            // if loop is off and if the CPU asks for interrupt:
-            else if (irq_enable)
-            {
-                irq_pending = true;     // let CPU jump in
-            }
-        }
-
-        // take control of the data bus for 4 cycles
-        pending_stall_cycles = 4;
-
-        return true;
-    }
-
-    void DeltaModulationChannel::play_sample()
-    {
-        // check if channel is busy:
-        if (bytes_remaining == 0)
-        {
-            // start loaded byte:
-            current_address = 0xC000 | (uint16_t(sample_address) << 6);
-            bytes_remaining = (uint16_t(sample_length) << 4) + 1;
-        }
-    }
-
-    void DeltaModulationChannel::reset()
-    {
-        // reset dmc class values back to the defaults defined in apu.hpp (1 exeption):
-        irq_enable = false;
-        irq_pending = false;
-        enabled = false;
-        loop = false;
-        sample_buffer_full = false;
-        silence = true;     // silence channel until CPU provides sample
-        rate_index = 0;
-        output_level = 0;
-        sample_address = 0;
-        sample_length = 0;
-        sample_buffer = 0;
-        current_address = 0;
-        bytes_remaining = 0;
-        timer_counter = 0;
-        shift_reg = 0;
-        bits_remaining = 0;
-        pending_stall_cycles = 0;
     }
 }
 
+void PulseChannel::clock_timer()
+{
+    if (timer_counter == 0)
+    {
+        sequencer_position = (sequencer_position + 1) & 0x07;
+        timer_counter = timer_period;
+    }
+    else
+    {
+        timer_counter--;
+    }
+}
+
+void PulseChannel::clock_envelope()
+{
+    envelope.clock();
+}
+
+void PulseChannel::clock_length_and_sweep()
+{
+    length_counter.clock();
+    sweep.clock(timer_period);
+}
+
+uint8_t PulseChannel::output() const
+{
+    if (!enabled)                                          return 0;
+    if (length_counter.counter == 0)                       return 0;
+    if (timer_period < 8)                                  return 0;
+    if (!DUTY_TABLE[duty_mode][sequencer_position])        return 0;
+    if (SweepUnit::is_muting(sweep.calculate_target_period(timer_period)))
+                                                           return 0;
+    return envelope.output();
+}
+
+void PulseChannel::reset()
+{
+    enabled            = false;
+    timer_period       = 0;
+    timer_counter      = 0;
+    duty_mode          = 0;
+    sequencer_position = 0;
+
+    envelope.reset();
+    length_counter.reset();
+    sweep.reset();
+}
+
+// ============================================================================
+// Triangle
+// ============================================================================
+
+// BUG FIX: the original table was missing values 0 and 9 in the ascending
+// half, producing audible glitches.  Correct 32-step triangle sequence:
+const uint8_t Triangle::SEQUENCE[32] = {
+    15, 14, 13, 12, 11, 10,  9,  8,  7,  6,  5,  4,  3,  2,  1,  0,
+     0,  1,  2,  3,  4,  5,  6,  7,  8,  9, 10, 11, 12, 13, 14, 15
+};
+
+void Triangle::write_register(uint8_t reg, uint8_t value)
+{
+    switch (reg & 0x03)
+    {
+    case 0: // $4008  CRRR RRRR
+    {
+        control_flag         = (value & 0x80) != 0;
+        length_counter.halt  = control_flag;
+        counter_reload_value = value & 0x7F;
+        break;
+    }
+    case 1: // $4009 — unused
+        break;
+    case 2: // $400A  TTTT TTTT  (timer low 8 bits)
+    {
+        timer_period = (timer_period & 0x0700) | value;
+        break;
+    }
+    case 3: // $400B  LLLL LTTT  (length load + timer high 3 bits)
+    {
+        timer_period = (timer_period & 0x00FF) | (static_cast<uint16_t>(value & 0x07) << 8);
+        length_counter.load((value >> 3) & 0x1F);
+        linear_reload_flag = true;
+        break;
+    }
+    }
+}
+
+void Triangle::clock_timer()
+{
+    if (timer_counter != 0)
+    {
+        timer_counter--;
+        return;
+    }
+
+    timer_counter = timer_period;
+
+    // Sequencer only advances when both counters are non-zero.
+    // Silence is like Pause — unsilencing resumes from the last step.
+    if (linear_counter > 0 && length_counter.counter > 0)
+        sequencer_step = (sequencer_step + 1) & 0x1F;
+}
+
+void Triangle::clock_linear_counter()
+{
+    // https://www.nesdev.org/wiki/APU_Triangle#Linear_counter
+    if (linear_reload_flag)
+        linear_counter = counter_reload_value;
+    else if (linear_counter != 0)
+        linear_counter--;
+
+    // Reload flag is only cleared when control_flag is also clear.
+    if (!control_flag)
+        linear_reload_flag = false;
+}
+
+uint8_t Triangle::output() const
+{
+    if (!enabled || length_counter.counter == 0 || linear_counter == 0)
+        return 0;
+    return SEQUENCE[sequencer_step];
+}
+
+void Triangle::reset()
+{
+    control_flag         = false;
+    counter_reload_value = 0;
+    linear_counter       = 0;
+    linear_reload_flag   = false;
+    timer_period         = 0;
+    timer_counter        = 0;
+    sequencer_step       = 0;
+    enabled              = false;
+    length_counter.reset();
+}
+
+// ============================================================================
+// Noise
+// ============================================================================
+
+void Noise::write_register(uint8_t reg, uint8_t value)
+{
+    switch (reg)
+    {
+    case 0: // $400C  --LC VVVV
+    {
+        const bool halt_or_loop          = (value & 0x20) != 0;
+        envelope.loop_flag               = halt_or_loop;
+        length_counter.halt              = halt_or_loop;
+        envelope.constant_volume_flag    = (value & 0x10) != 0;
+        envelope.volume_period           = value & 0x0F;
+        break;
+    }
+    // case 1: $400D — unused
+    case 2: // $400E  M--- PPPP
+    {
+        mode_flag          = (value & 0x80) != 0;
+        timer_period_index = value & 0x0F;
+        break;
+    }
+    case 3: // $400F  LLLL L---
+    {
+        length_counter.load(value >> 3);
+        envelope.start_flag = true;
+        break;
+    }
+    }
+}
+
+void Noise::clock_timer()
+{
+    if (timer_counter == 0)
+    {
+        timer_counter = TIMER_PERIOD[timer_period_index];
+        clock_shift_register();
+    }
+    else
+    {
+        timer_counter--;
+    }
+}
+
+void Noise::clock_shift_register()
+{
+    const uint8_t  feedback_bit = mode_flag ? 6 : 1;
+    const uint16_t feedback     = (lfsr & 1) ^ ((lfsr >> feedback_bit) & 1);
+    lfsr = (lfsr >> 1) | (feedback << 14);
+}
+
+void Noise::clock_envelope()
+{
+    envelope.clock();
+}
+
+uint8_t Noise::output() const
+{
+    if ((lfsr & 1) || length_counter.counter == 0)
+        return 0;
+    return envelope.output();
+}
+
+void Noise::reset()
+{
+    mode_flag          = false;
+    timer_period_index = 0;
+    timer_counter      = 0;
+    lfsr               = 1;
+    enabled            = false;
+
+    envelope.reset();
+    length_counter.reset();
+}
+
+// ============================================================================
+// DeltaModulationChannel
+// ============================================================================
+
+void DeltaModulationChannel::attach_memory(Memory* mem)
+{
+    memory_ = mem;
+}
+
+void DeltaModulationChannel::write_register(uint8_t reg, uint8_t value)
+{
+    switch (reg)
+    {
+    case 0: // $4010  IL-- RRRR
+        irq_enabled = (value & 0x80) != 0;
+        loop        = (value & 0x40) != 0;
+        rate_index  = value & 0x0F;
+        if (!irq_enabled)
+            irq_pending = false;
+        break;
+
+    case 1: // $4011  -DDD DDDD  (direct load)
+        output_level = value & 0x7F;
+        break;
+
+    case 2: // $4012  AAAA AAAA
+        sample_address = value;
+        break;
+
+    case 3: // $4013  LLLL LLLL
+        sample_length = value;
+        break;
+    }
+}
+
+void DeltaModulationChannel::start_sample()
+{
+    if (bytes_remaining == 0)
+    {
+        current_address = decode_address(sample_address);
+        bytes_remaining = decode_length(sample_length);
+    }
+}
+
+bool DeltaModulationChannel::fetch_sample_byte()
+{
+    if (memory_ == nullptr)
+        return false;
+
+    sample_buffer      = memory_->read(current_address);
+    sample_buffer_full = true;
+
+    // Advance address with wrap at $FFFF → $8000
+    current_address++;
+    if (current_address == 0)
+        current_address = 0x8000;
+
+    bytes_remaining--;
+    if (bytes_remaining == 0)
+    {
+        if (loop)
+        {
+            current_address = decode_address(sample_address);
+            bytes_remaining = decode_length(sample_length);
+        }
+        else if (irq_enabled)
+        {
+            irq_pending = true;
+        }
+    }
+
+    // DMA fetch stalls the CPU for ~4 cycles due to bus contention.
+    pending_stall_cycles = 4;
+    return true;
+}
+
+void DeltaModulationChannel::clock_memory_reader()
+{
+    if (!sample_buffer_full && bytes_remaining > 0)
+        fetch_sample_byte();
+}
+
+void DeltaModulationChannel::clock_output_unit()
+{
+    // End of output cycle: reload shift register from sample buffer.
+    if (bits_remaining == 0)
+    {
+        bits_remaining = 8;
+
+        if (sample_buffer_full)
+        {
+            silence            = false;
+            shift_register     = sample_buffer;
+            sample_buffer_full = false;
+        }
+        else
+        {
+            silence = true;
+        }
+    }
+
+    // Apply the current delta bit to the output level.
+    if (!silence)
+    {
+        if (shift_register & 1)
+        {
+            if (output_level <= 125) output_level += 2;
+        }
+        else
+        {
+            if (output_level >= 2)   output_level -= 2;
+        }
+        shift_register >>= 1;
+    }
+
+    bits_remaining--;
+}
+
+void DeltaModulationChannel::clock_timer()
+{
+    if (timer_counter == 0)
+    {
+        timer_counter = RATE_TABLE[rate_index];
+        clock_output_unit();
+    }
+    else
+    {
+        timer_counter--;
+    }
+}
+
+uint8_t DeltaModulationChannel::output() const
+{
+    return output_level;
+}
+
+void DeltaModulationChannel::reset()
+{
+    irq_enabled         = false;
+    irq_pending         = false;
+    enabled             = false;
+    loop                = false;
+    rate_index          = 0;
+    output_level        = 0;
+    sample_address      = 0;
+    sample_length       = 0;
+    sample_buffer       = 0;
+    sample_buffer_full  = false;
+    current_address     = 0;
+    bytes_remaining     = 0;
+    timer_counter       = 0;
+    shift_register      = 0;
+    bits_remaining      = 0;
+    silence             = true; // silent until CPU provides a sample
+    pending_stall_cycles = 0;
+}
+
+// ============================================================================
+// APU
+// ============================================================================
+
+APU::APU() { reset(); }
+
+void APU::reset()
+{
+    frame_counter_step   = 0;
+    frame_counter_cycles = 0;
+    frame_counter_mode   = false;
+    frame_irq_inhibit    = false;
+    frame_irq_flag       = false;
+    status_enable        = 0;
+    cpu_cycle            = 0;
+
+    write_status(0x00);
+
+    pulse1.reset();
+    pulse2.reset();
+    triangle.reset();
+    noise.reset();
+    dmc.reset();
+}
+
+// https://www.nesdev.org/wiki/APU_Frame_Counter
+//
+// 4-step mode (mode = 0):               5-step mode (mode = 1):
+//   Step 1: quarter                        Step 1: quarter
+//   Step 2: quarter + half                 Step 2: quarter + half
+//   Step 3: quarter                        Step 3: quarter
+//   Step 4: quarter + half + IRQ           Step 4: (nothing)
+//                                          Step 5: quarter + half
+void APU::clock_frame_counter()
+{
+    frame_counter_cycles++;
+
+    if (frame_counter_mode) // 5-step
+    {
+        switch (frame_counter_cycles)
+        {
+        case 3728:  clock_quarter_frame(); break;
+        case 7456:  clock_quarter_frame(); clock_half_frame(); break;
+        case 11185: clock_quarter_frame(); break;
+        case 14914: break; // silent step
+        case 18640:
+            clock_quarter_frame();
+            clock_half_frame();
+            frame_counter_cycles = 0;
+            break;
+        }
+    }
+    else // 4-step
+    {
+        switch (frame_counter_cycles)
+        {
+        case 3728:  clock_quarter_frame(); break;
+        case 7456:  clock_quarter_frame(); clock_half_frame(); break;
+        case 11185: clock_quarter_frame(); break;
+        case 14914:
+            clock_quarter_frame();
+            clock_half_frame();
+            if (!frame_irq_inhibit)
+                frame_irq_flag = true;
+            frame_counter_cycles = 0;
+            break;
+        }
+    }
+}
+
+void APU::clock_quarter_frame()
+{
+    pulse1.clock_envelope();
+    pulse2.clock_envelope();
+    noise.clock_envelope();
+    triangle.clock_linear_counter();
+}
+
+void APU::clock_half_frame()
+{
+    pulse1.clock_length_and_sweep();
+    pulse2.clock_length_and_sweep();
+    noise.length_counter.clock();
+    triangle.length_counter.clock();
+}
+
+void APU::step()
+{
+    cpu_cycle++;
+    clock_frame_counter();
+
+    // Triangle ticks every CPU cycle.
+    triangle.clock_timer();
+
+    // Pulse, noise, and DMC tick every other CPU cycle (APU rate).
+    if ((cpu_cycle & 1) == 0)
+    {
+        pulse1.clock_timer();
+        pulse2.clock_timer();
+        noise.clock_timer();
+        dmc.clock_timer();
+    }
+}
+
+// ── Register interface ──────────────────────────────────────────────────
+
+void APU::write_register(uint16_t address, uint8_t value)
+{
+    if (address < 0x4000 || address > 0x4017)
+        return;
+
+    switch (address)
+    {
+    case 0x4015: write_status(value);        return;
+    case 0x4017: write_frame_counter(value); return;
+
+    case 0x4000: case 0x4001: case 0x4002: case 0x4003:
+        pulse1.write_register(address - 0x4000, value); return;
+
+    case 0x4004: case 0x4005: case 0x4006: case 0x4007:
+        pulse2.write_register(address - 0x4004, value); return;
+
+    case 0x4008: case 0x4009: case 0x400A: case 0x400B:
+        triangle.write_register(address - 0x4008, value); return;
+
+    case 0x400C: case 0x400D: case 0x400E: case 0x400F:
+        noise.write_register(address - 0x400C, value); return;
+
+    case 0x4010: case 0x4011: case 0x4012: case 0x4013:
+        dmc.write_register(address - 0x4010, value); return;
+
+    default: return;
+    }
+}
+
+// $4015 write  ---D NT21
+void APU::write_status(uint8_t value)
+{
+    status_enable = value & 0x1F;
+
+    pulse1.enabled = (status_enable & 0x01) != 0;
+    if (!pulse1.enabled) pulse1.length_counter.clear();
+
+    pulse2.enabled = (status_enable & 0x02) != 0;
+    if (!pulse2.enabled) pulse2.length_counter.clear();
+
+    triangle.enabled = (status_enable & 0x04) != 0;
+    if (!triangle.enabled) triangle.length_counter.clear();
+
+    noise.enabled = (status_enable & 0x08) != 0;
+    if (!noise.enabled) noise.length_counter.clear();
+
+    dmc.enabled = (status_enable & 0x10) != 0;
+
+    // "Writing to this register clears the DMC interrupt flag."
+    dmc.irq_pending = false;
+}
+
+// $4017 write  MI-- ----
+void APU::write_frame_counter(uint8_t value)
+{
+    frame_irq_inhibit  = (value & 0x40) != 0;
+    frame_counter_mode = (value & 0x80) != 0;
+
+    if (frame_irq_inhibit)
+        frame_irq_flag = false;
+
+    frame_counter_step   = 0;
+    frame_counter_cycles = 0;
+
+    // 5-step mode immediately generates quarter + half frame clocks.
+    if (frame_counter_mode)
+    {
+        clock_quarter_frame();
+        clock_half_frame();
+    }
+}
+
+// $4015 read  IF-D NT21
+uint8_t APU::read_status()
+{
+    uint8_t status = 0;
+
+    if (pulse1.length_counter.is_active())   status |= 0x01;
+    if (pulse2.length_counter.is_active())   status |= 0x02;
+    if (triangle.length_counter.is_active()) status |= 0x04;
+    if (noise.length_counter.is_active())    status |= 0x08;
+    if (dmc.bytes_remaining > 0)             status |= 0x10;
+    if (frame_irq_flag)                      status |= 0x40;
+    if (dmc.irq_pending)                     status |= 0x80;
+
+    // Reading $4015 clears the frame interrupt flag.
+    frame_irq_flag  = false;
+    // Note: NES Dev documents a same-cycle race condition where the flag
+    // reads as 1 but isn't cleared; we don't emulate that edge case.
+
+    return status;
+}
+
+// ── Mixer (lookup-free approximation) ───────────────────────────────────
+// https://www.nesdev.org/wiki/APU_Mixer
+
+float APU::get_output() const
+{
+    return get_pulse_output() + get_tnd_output();
+}
+
+//                     95.88
+// pulse_out = ──────────────────────────
+//             (8128 / (p1 + p2)) + 100
+float APU::get_pulse_output() const
+{
+    const float sum = static_cast<float>(pulse1.output() + pulse2.output());
+    if (sum == 0.0f) return 0.0f;
+    return 95.88f / ((8128.0f / sum) + 100.0f);
+}
+
+//                         159.79
+// tnd_out = ─────────────────────────────────────────
+//           1/(t/8227 + n/12241 + d/22638) + 100
+float APU::get_tnd_output() const
+{
+    const float t = static_cast<float>(triangle.output());
+    const float n = static_cast<float>(noise.output());
+    const float d = static_cast<float>(dmc.output());
+
+    const float denom = (t / 8227.0f) + (n / 12241.0f) + (d / 22638.0f);
+    if (denom == 0.0f) return 0.0f;
+    return 159.79f / ((1.0f / denom) + 100.0f);
+}
+
+} // namespace nes


### PR DESCRIPTION
Bug fix:

Triangle SEQUENCE table — the original was missing values 0 and 9 in the ascending half (it jumped 0, 1, 2, 3, 4, 5, 6, 7, 8, 10, 11... — only 30 entries for a 32-step table). Fixed to the correct symmetric triangle wave.

Bug fix:

Envelope::output() — returned decay_level unconditionally, ignoring constant_volume_flag. Now correctly returns volume_period when constant volume is selected. This means the Noise channel's redundant constant_volume_flag / volume_envelope_divider_period fields (which duplicated what the Envelope already tracks) could be removed.

Structural improvements:

Noise channel — removed the redundant length_counter_halt, constant_volume_flag, and volume_envelope_divider_period fields that just shadowed envelope.* and length_counter.halt. Writes now go directly to the sub-unit fields, eliminating a class of desync bugs. Noise/Triangle in clock_half_frame() — the original only clocked pulse length counters and sweeps in the half-frame. Noise and Triangle length counters were never clocked there. Now all four channels' length counters are clocked on half-frame. DMC — memory pointer moved to private (memory_); fetch_sample_byte, clock_output_unit, clock_memory_reader made private. Added decode_address() / decode_length() helpers to eliminate the duplicated 0xC000 | (addr << 6) / (len << 4) + 1 arithmetic. read_status() — uses length_counter.is_active() instead of reaching into .counter > 0 directly. APU mixer helpers — get_pulse_output() / get_tnd_output() moved to private since only get_output() is the public API. Removed the $4000–$4017 named register fields that were declared but never read. write_status/write_frame_counter moved to private since they're only called via write_register().

Naming:

is_pulse1 → is_channel1 (less ambiguous)
shift_register_state → lfsr (standard term, matches comment) shift_reg → shift_register (DMC)
play_sample() → start_sample() (clarifies it configures playback, doesn't play a single sample) irq_enable → irq_enabled (adjective for state)
LENGTH_TABLE → TABLE, SEQUENCER_TABLE → SEQUENCE (parent class provides context) RATE → RATE_TABLE, clock_memory_unit → clock_memory_reader

Style:

Moved public method declarations above public data members in all classes (interface-first) Eliminated > 0.0f float comparisons in favor of == 0.0f early returns Added explicit static_cast<float>() instead of relying on implicit narrowing conversions Consolidated verbose block comments into concise per-class doc blocks in the header Removed ~180 lines of redundant inline comments in the cpp that just restated the code Consistent alignment of initializers and switch cases Flattened the Envelope::clock() control flow (early-return instead of deeply nested if/else) SweepUnit::clock() restructured to handle the reload_flag properly alongside divider expiry (the original would skip the period update when reload_flag was set and divider was simultaneously 0)