### PR TITLE
Fix controller strobe logic and shift registers in memory tests

### DIFF
--- a/CMakeSettings.json
+++ b/CMakeSettings.json
@@ -1,0 +1,22 @@
+﻿{
+  "configurations": [
+    {
+      "name": "x64-Debug",
+      "generator": "Ninja",
+      "configurationType": "Debug",
+      "inheritEnvironments": [ "msvc_x64_x64" ],
+      "buildRoot": "${projectDir}\\out\\build\\${name}",
+      "installRoot": "${projectDir}\\out\\install\\${name}",
+      "cmakeCommandArgs": "",
+      "buildCommandArgs": "",
+      "ctestCommandArgs": "",
+      "variables": [
+        {
+          "name": "SFML_DIR",
+          "value": "C:/SFML-2.6.2/lib/cmake/SFML",
+          "type": "PATH"
+        }
+      ]
+    }
+  ]
+}

--- a/include/nes/mem.hpp
+++ b/include/nes/mem.hpp
@@ -15,9 +15,16 @@ public:
     // Map PRG ROM into $8000-$FFFF. For NROM, either 16KB mirrored or 32KB.
     void map_prg(const uint8_t* prg_data, std::size_t prg_size);
 
-    // Controller latches (simple placeholders)
-    void set_controller1(uint8_t v) { controller1 = v; }
-    void set_controller2(uint8_t v) { controller2 = v; }
+    // Update physical button state.
+    // If strobe is active, it continuously loads into the shift register.
+    void set_controller1(uint8_t v) {
+        controller1 = v;
+        if (strobe) controller1_shift = v;
+    }
+    void set_controller2(uint8_t v) {
+        controller2 = v;
+        if (strobe) controller2_shift = v;
+    }
 
     // Reset memory-mapped state back to a known state (does not modify ROM bytes)
     void reset();
@@ -33,6 +40,13 @@ private:
     // Controller registers (placeholders)
     uint8_t controller1 = 0;
     uint8_t controller2 = 0;
+
+    // Internal shift registers (read by the CPU bit-by-bit)
+    uint8_t controller1_shift = 0;
+    uint8_t controller2_shift = 0;
+
+	// Strobe state for controllers (bit 0 of $4016)
+	bool strobe = false;
 
     // PPU/APU registers (placeholders)
     uint8_t ppu_regs[8]{};

--- a/src/nes/mem.cpp
+++ b/src/nes/mem.cpp
@@ -13,6 +13,8 @@ void Memory::reset() {
     std::memset(ppu_regs, 0, sizeof(ppu_regs));
     std::memset(apu_regs, 0, sizeof(apu_regs));
     controller1 = controller2 = 0;
+	controller1_shift = controller2_shift = 0;
+	strobe = false;
     oam_dma = 0;
     // prg pointer and size are left as-is; console will re-map on ROM load
 }
@@ -40,8 +42,22 @@ uint8_t Memory::read(uint16_t addr) {
 
     // $4000-$4017: APU and I/O
     if (addr < 0x4018) {
-        if (addr == 0x4016) return controller1;
-        if (addr == 0x4017) return controller2;
+        if (addr == 0x4016) {
+            // If strobe is high, continuously read the 'A' button state
+            if (strobe) return controller1 & 1;
+
+            // Otherwise, read bit 0 and shift right
+            uint8_t ret = controller1_shift & 1;
+            controller1_shift >>= 1;
+            return ret;
+        }
+        if (addr == 0x4017) {
+            if (strobe) return controller2 & 1;
+
+            uint8_t ret = controller2_shift & 1;
+            controller2_shift >>= 1;
+            return ret;
+        }
         if (addr == 0x4014) return oam_dma;
         return apu_regs[addr - 0x4000];
     }
@@ -78,8 +94,25 @@ void Memory::write(uint16_t addr, uint8_t value) {
     // $4000-$4017: APU and I/O
     if (addr < 0x4018) {
         if (addr == 0x4014) { oam_dma = value; return; }
-        if (addr == 0x4016) { controller1 = value; return; }
-        if (addr == 0x4017) { controller2 = value; return; }
+
+        // Writing to 0x4016 controls the strobe latch for BOTH controllers
+        if (addr == 0x4016) {
+            strobe = (value & 1);
+            if (strobe) {
+                // While strobe is high, copy physical state into shift registers
+                controller1_shift = controller1;
+                controller2_shift = controller2;
+            }
+            return;
+        }
+
+        // Note: Writing to 0x4017 does NOT affect the controllers on the NES. 
+        // It is strictly for the APU frame counter.
+        if (addr == 0x4017) {
+            apu_regs[addr - 0x4000] = value;
+            return;
+        }
+
         apu_regs[addr - 0x4000] = value;
         return;
     }


### PR DESCRIPTION
This PR updates the Memory class to accurately emulate the NES controller hardware. Previously, the controller ports ($4016 and $4017) were being treated as standard writable memory registers, which was overwriting the physical button states and causing the controller input tests to fail.

This update separates the physical button state from the shift register read by the CPU, fully implementing the strobe latch sequence required for the emulator to read inputs bit-by-bit.

Changes Made:

- Added hardware state variables to mem.hpp: Introduced controller1_shift, controller2_shift, and a boolean strobe flag to track the internal shift registers and latch state.
- 
- Updated Memory::write() for $4016 / $4017: Writing 1 to $4016 now properly sets the strobe flag and continuously copies the physical button states into the shift registers.
- 
- Updated Memory::read() for $4016 / $4017: Reading these addresses now correctly returns the 0th bit of the shift register and shifts the remaining bits to the right (>>= 1).
- 
- Updated Memory::reset(): Ensured the new shift registers and strobe flag are zeroed out upon a system reset.

Testing:

- Ran mem_tests.exe locally.
- 
- The "Controller Strobe & Shift Register" test now successfully passes, confirming the bitwise shift logic aligns with standard NES hardware behavior.