### PR TITLE
Theo/improve UI

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -71,8 +71,18 @@ FetchContent_MakeAvailable(nfd)
 
 # Make NFD sources available to build: include headers and compile zenity backend
 set(NFD_SRC_DIR ${nfd_SOURCE_DIR}/src)
+set(NFD_SOURCES
+        ${NFD_SRC_DIR}/nfd_common.c
+        ${NFD_SRC_DIR}/nfd_zenity.c
+)
+
 target_include_directories(nes_ui PUBLIC ${NFD_SRC_DIR}/include)
-target_sources(nes_ui PRIVATE ${NFD_SRC_DIR}/nfd_common.c ${NFD_SRC_DIR}/nfd_zenity.c)
+target_sources(nes_ui PRIVATE ${NFD_SOURCES})
+
+# Silence warning only for NFD sources (GNU/Clang only)
+set_source_files_properties(${NFD_SOURCES} PROPERTIES
+        COMPILE_FLAGS "$<$<C_COMPILER_ID:GNU,Clang>:-Wno-format-truncation>"
+)
 
 # Link UI target with SFML, nes_lib and gtest
 target_link_libraries(nes_ui PUBLIC sfml-graphics sfml-window sfml-system nes_lib GTest::gtest_main GTest::gtest)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.20)
-project(NES_Emulator LANGUAGES CXX)
+project(NES_Emulator LANGUAGES CXX C)
 
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
@@ -59,7 +59,26 @@ target_include_directories(nes_ui
         $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
         $<INSTALL_INTERFACE:include>
 )
-target_link_libraries(nes_ui PUBLIC sfml-graphics sfml-window sfml-system)
+include(FetchContent)
+
+# Fetch nativefiledialog (NFD) so <nfd.h> and the library are available
+FetchContent_Declare(
+    nfd
+    GIT_REPOSITORY https://github.com/mlabbe/nativefiledialog.git
+    GIT_TAG        master
+)
+FetchContent_MakeAvailable(nfd)
+
+# Make NFD sources available to build: include headers and compile zenity backend
+set(NFD_SRC_DIR ${nfd_SOURCE_DIR}/src)
+target_include_directories(nes_ui PUBLIC ${NFD_SRC_DIR}/include)
+target_sources(nes_ui PRIVATE ${NFD_SRC_DIR}/nfd_common.c ${NFD_SRC_DIR}/nfd_zenity.c)
+
+# Link UI target with SFML, nes_lib and gtest
+target_link_libraries(nes_ui PUBLIC sfml-graphics sfml-window sfml-system nes_lib GTest::gtest_main GTest::gtest)
+if(TGUI_FOUND)
+    target_link_libraries(nes_ui PUBLIC TGUI::TGUI)
+endif()
 
 # ---- Executable with main.cpp; link SDL, and UI ----
 add_executable(nes_emu ${PROJECT_SOURCE_DIR}/src/main.cpp

--- a/include/nes/console.hpp
+++ b/include/nes/console.hpp
@@ -14,7 +14,7 @@ public:
     console();
     ~console();
 
-    bool load_rom(char* filepath);
+    bool load_rom(const char* filepath);
     bool rom_loaded() const;
 
     void run_rom();

--- a/include/ui/ui.hpp
+++ b/include/ui/ui.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <SFML/Graphics.hpp>
+#include <nfd.h>
 
 class console;
 

--- a/src/nes/console.cpp
+++ b/src/nes/console.cpp
@@ -15,7 +15,7 @@ console::console()
 }
 console::~console() = default;
 
-bool console::load_rom(char* filepath) {
+bool console::load_rom(const char* filepath) {
     if (!rom.load_from_file(filepath)) {
         std::fprintf(stderr, "[console] Failed to load ROM: %s\n", filepath);
         return false;
@@ -109,6 +109,9 @@ void console::reset_all() {
     cpu.reset();
     rom.reset();
     mem.reset();
+    ppu.reset();
+    apu.reset();
+    std::memset(framebuffer_data, 0, sizeof(framebuffer_data)); // Clear framebuffer
     std::fprintf(stderr, "[console] Reset complete\n");
 }
 

--- a/src/ui/ui.cpp
+++ b/src/ui/ui.cpp
@@ -1,24 +1,73 @@
 #include "ui/ui.hpp"
 #include "nes/console.hpp"
 #include <SFML/Graphics.hpp>
+#include <algorithm>
 
 namespace {
     sf::RenderWindow* g_window = nullptr;
     sf::Texture g_texture;
     sf::Sprite g_sprite;
+    bool g_fullscreen = false;
     
     constexpr unsigned int SCALE = 3;  // Scale up the 256x240 resolution since it's so small
     constexpr unsigned int FB_WIDTH = 256;
     constexpr unsigned int FB_HEIGHT = 240;
+
+    // Update sprite scale and position based on current window size
+    static void update_view() {
+        if (!::g_window) return;
+        sf::Vector2u winSize = ::g_window->getSize();
+
+        // Compute scale to fit framebuffer into window while preserving aspect ratio
+        float scaleX = static_cast<float>(winSize.x) / static_cast<float>(FB_WIDTH);
+        float scaleY = static_cast<float>(winSize.y) / static_cast<float>(FB_HEIGHT);
+
+        float scale = ::g_fullscreen ? std::min(scaleX, scaleY) : static_cast<float>(SCALE);
+
+        ::g_sprite.setScale(scale, scale);
+
+        // Center the sprite in the window
+        float offsetX = (static_cast<float>(winSize.x) - FB_WIDTH * scale) / 2.0f;
+        float offsetY = (static_cast<float>(winSize.y) - FB_HEIGHT * scale) / 2.0f;
+        ::g_sprite.setPosition(offsetX, offsetY);
+
+        // Ensure the view covers the whole window
+        ::g_window->setView(sf::View(sf::FloatRect(0.f, 0.f, static_cast<float>(winSize.x), static_cast<float>(winSize.y))));
+    }
 }
 
 namespace ui {
+
+    std::string openFileDialog()
+    {
+        nfdchar_t* outPath = nullptr;
+        nfdresult_t result = NFD_OpenDialog(nullptr, nullptr, &outPath);
+
+        if (result == NFD_OKAY)
+        {
+            std::string path = outPath;
+            free(outPath);
+            return path;
+        }
+        else if (result == NFD_CANCEL)
+        {
+            printf("User pressed cancel.\n");
+        }
+        else
+        {
+            printf("Error: %s\n", NFD_GetError());
+        }
+
+        return "";
+    }
+
     bool init() {
         try {
             ::g_window = new sf::RenderWindow(
                 sf::VideoMode(FB_WIDTH * SCALE, FB_HEIGHT * SCALE),
                 "NES Emulator"
             );
+            ::g_fullscreen = false;
             
             if (!::g_window->isOpen()) {
                 delete ::g_window;
@@ -36,7 +85,7 @@ namespace ui {
             
             // Setup sprite
             ::g_sprite.setTexture(::g_texture);
-            ::g_sprite.setScale(SCALE, SCALE);
+            update_view();
             
             ::g_window->setFramerateLimit(60);
             
@@ -59,19 +108,76 @@ namespace ui {
                 ::g_window->close();
                 return false;
             }
-            if (event.type == sf::Event::KeyPressed && event.key.code == sf::Keyboard::Escape) {
-                is_running = false;
-                ::g_window->close();
-                return false;
-            }
-            if (event.type == sf::Event::KeyPressed && event.key.code == sf::Keyboard::Space) {
-                if (emu.rom_loaded()) {
-                    if (!is_running) {
-                        std::fprintf(stderr, "Resuming emulation\n");
-                    } else {
-                        std::fprintf(stderr, "Pausing emulation\n");
+            // Handle keyboard input for controlling the emulator
+            // Space - toggle pause/resume
+            // S - step one frame
+            // R - reset emulator
+            // F - toggle fullscreen
+            // L - load ROM
+            auto tppe = event.type;
+            if (event.type == sf::Event::KeyPressed){
+                switch (event.key.code)
+                {
+                    case sf::Keyboard::Escape:
+                        is_running = false;
+                        ::g_window->close();
+                        return false;
+                        break;
+                    case sf::Keyboard::Space:
+                        if (emu.rom_loaded()) {
+                            if (!is_running) {
+                                std::fprintf(stderr, "Resuming emulation\n");
+                            } else {
+                                std::fprintf(stderr, "Pausing emulation\n");
+                            }
+                            is_running = !is_running;
+                        }
+                        break;
+                    case sf::Keyboard::S:
+                        if (emu.rom_loaded()) {
+                            std::fprintf(stderr, "Stepping one frame\n");
+                            emu.step(1);
+                        }
+                        break;
+                    case sf::Keyboard::R:
+                        if (emu.rom_loaded()) {
+                            std::fprintf(stderr, "Resetting emulator\n");
+                            emu.reset_all();
+                            is_running = false;
+                        }
+                        break;
+                    case sf::Keyboard::F:
+                        if (emu.rom_loaded()) {
+                            std::fprintf(stderr, "Toggling fullscreen\n");
+                            if (::g_fullscreen) {
+                                ::g_window->create(sf::VideoMode(FB_WIDTH * SCALE, FB_HEIGHT * SCALE), "NES Emulator", sf::Style::Default);
+                            } else {
+                                ::g_window->create(sf::VideoMode::getDesktopMode(), "NES Emulator", sf::Style::Fullscreen);
+                            }
+                            // Reapply settings for the new window
+                            ::g_window->setFramerateLimit(60);
+                            ::g_fullscreen = !::g_fullscreen;
+                            update_view();
+                        }
+                        break;
+                    case sf::Keyboard::L:{
+                        if (emu.rom_loaded()) {
+                            // unload rom
+                            std::fprintf(stderr, "Unloading current ROM\n");
+                            emu.reset_all();
+                            is_running = false;
+                        }
+                        // add file select menu
+                        std::string filePath = openFileDialog();
+                        if (!filePath.empty()) {
+                            std::fprintf(stderr, "Loading ROM: %s\n", filePath.c_str());
+                            emu.load_rom(filePath.c_str());
+                            is_running = true;
+                        }
                     }
-                    is_running = !is_running;
+                        break;
+                    default:
+                        break;
                 }
             }
         }


### PR DESCRIPTION
- Added NFD to CMake file (please check that this works on all platforms; I was only able to test on Linux).
- Updated Console.reset_all() to also reset the PPU and APU
- Updated Console.load_rom() to take a const string (better memory safety)
- Added keybinds to UI for the following:
Esc - Exit program
Space - pause/resume playback
S - step a single frame
R - reset emulator
F - toggle fullscreen
L - load ROM

I ended up not being able to add a menu bar for the UI actions due to SFML compatibility issues. SFML does not have a way to directly act on the window, so something would need to be made and rendered instead. I tested out some libraries, such as ImGUI and TGUI, but they either had issues working on Linux or did not fit our codebase. I also considered switching to something like QT for our rendering, but I think it is too late in the dev process for that now. If someone would like to take a crack at addressing the issues, I welcome it, but for now I think it's best to stick with this and focus on spending effort elsewhere.