### PR TITLE
Implemented the interrupt opcodes (only BRK was needed, RTI was already implemented)

### DIFF
--- a/src/nes/cpu.cpp
+++ b/src/nes/cpu.cpp
@@ -209,6 +209,86 @@ int CPU::step() {
             cycles_until_cpu_boundary += 2;
             break;
         }
+        case 0x30: { // bmi rel
+            // fetch offset
+            int8_t off = (int8_t)fetch8();
+            // base timing
+            cycles_until_cpu_boundary += 2;
+
+            // check status and n_flag
+            if (P & N_FLAG) {
+                // execute branch (1 cycle)
+                uint16_t old_pc = PC;
+                PC += off;
+                cycles_until_cpu_boundary += 1;
+                
+                // handle page crossing
+                if ((old_pc & 0xFF00) != (PC & 0xFF00)) // old and new pc are on different pages
+                    cycles_until_cpu_boundary += 1; // takes additional cycle if true
+            }
+
+            break;
+        }
+        case 0x50: { // bvc rel
+            // fetch offset
+            int8_t off = (int8_t)fetch8();
+            // base timing
+            cycles_until_cpu_boundary += 2;
+
+            // check status and v_flag (if overflow flag is clear)
+            if (!(P & V_FLAG)) {
+                // execute branch (1 cycle)
+                uint16_t old_pc = PC;
+                PC += off;
+                cycles_until_cpu_boundary += 1;
+                
+                // handle page crossing
+                if ((old_pc & 0xFF00) != (PC & 0xFF00)) // old and new pc are on different pages
+                    cycles_until_cpu_boundary += 1; // takes additional cycle if true
+            }
+
+            break;
+        }
+        case 0x70: { // bvs rel
+            // fetch offset
+            int8_t off = (int8_t)fetch8();
+            // base timing
+            cycles_until_cpu_boundary += 2;
+
+            // check status and v_flag
+            if ((P & V_FLAG)) {
+                // execute branch (1 cycle)
+                uint16_t old_pc = PC;
+                PC += off;
+                cycles_until_cpu_boundary += 1;
+                
+                // handle page crossing
+                if ((old_pc & 0xFF00) != (PC & 0xFF00)) // old and new pc are on different pages
+                    cycles_until_cpu_boundary += 1; // takes additional cycle if true
+            }
+
+            break;
+        }
+        case 0x90: { // bcc rel
+            // fetch offset
+            int8_t off = (int8_t)fetch8();
+            // base timing
+            cycles_until_cpu_boundary += 2;
+
+            // check status and c_flag (if carry flag is 0)
+            if (!(P & C_FLAG)) {
+                // execute branch (1 cycle)
+                uint16_t old_pc = PC;
+                PC += off;
+                cycles_until_cpu_boundary += 1;
+                
+                // handle page crossing
+                if ((old_pc & 0xFF00) != (PC & 0xFF00)) // old and new pc are on different pages
+                    cycles_until_cpu_boundary += 1; // takes additional cycle if true
+            }
+
+            break;
+        }
         case 0xD0: { // BNE rel
             int8_t off = (int8_t)fetch8();
             bool Z = (P & Z_FLAG) != 0;

--- a/src/nes/cpu.cpp
+++ b/src/nes/cpu.cpp
@@ -642,6 +642,32 @@ int CPU::step() {
             break;
         }
 
+        // ---- Interrupts ----
+        case 0x00: { // brk - force interrupt
+            // increment pc by 1 to prevent rti from executing brk in infinite loop
+            PC++;
+
+            // push pc high byte (8-15)
+            push((PC >> 8) & 0xFF);
+            // push pc low byte (0-7)
+            push(PC & 0xFF);
+            // push status reg
+            push(P | B_FLAG | U_FLAG);
+
+            // set i_flag to prevent nesting interrupts
+            P |= I_FLAG;
+
+            // load new pc from $FFFE (irq / brk vector)
+            PC = mem->read(0xFFFE);
+
+            // adjust timing
+            cycles_until_cpu_boundary += 7;
+            
+            break;
+        }
+        
+        // rti already implemented
+
         default:
             std::fprintf(stderr,
                          "[cpu] UNIMPL opcode=%02X at PC=%04X  A=%02X X=%02X Y=%02X P=%02X S=%02X\n",


### PR DESCRIPTION
Added the BRK opcode for software interruptions. The other interrupt opcode, RTI, was already implemented.

BRK (0x00) is a 2 byte instruction, where Program Counter (PC) has to be incremented by one (skipping the padding byte, 0x00) before preforming any work to prevent RTI from looping back to BRK infinitely. The second incrementation is not preformed in BRK, but elsewhere in the CPU. I felt like this needed some extra explanation, since it's weird and caught me off-guard when I was reading up on how to implement this opcode.