### PR TITLE
Defined and implemented the addressing mode helper functions. Next step is to utilise them in the opcodes

### DIFF
--- a/include/nes/cpu.hpp
+++ b/include/nes/cpu.hpp
@@ -52,6 +52,16 @@ private:
     void push(uint8_t v);
     uint8_t pop();
 
+    // addressing mode helpers
+    uint16_t addr_abs();
+    uint16_t addr_zp();
+    uint16_t addr_zpx();
+    uint16_t addr_zpy();
+    uint16_t addr_absx(bool check_page_cross = false);
+    uint16_t addr_absy(bool check_page_cross = false);
+    uint16_t addr_indx();
+    uint16_t addr_indy(bool check_page_cross = false);
+
     void init_state();
     void setZN(uint8_t v) {
         if (v == 0) P |= Z_FLAG; else P &= ~Z_FLAG;

--- a/src/nes/cpu.cpp
+++ b/src/nes/cpu.cpp
@@ -33,6 +33,78 @@ uint8_t CPU::pop() {
     return mem->read((uint16_t)(0x0100 | S));
 }
 
+// ---- addressing mode helpers -----
+uint16_t CPU::addr_abs() { // absolute
+    return fetch16();
+}
+
+uint16_t CPU::addr_zp() { // zero page
+    return fetch8();
+}
+
+uint16_t CPU::addr_zpx() { // zero page, x
+    // zero page indexing needs to wrap within $0000-$00FF
+    return (addr_zp() + X) & 0xFF;
+}
+
+uint16_t CPU::addr_zpy() { // zero page, y
+    // zero page indexing needs to wrap within $0000-$00FF
+    return (addr_zp() + Y) & 0xFF;
+}
+
+uint16_t CPU::addr_absx(bool check_page_cross = false) { // absolute indexed, x
+    uint16_t base = addr_abs();
+    uint16_t addr = base + X;
+
+    // check high byte for changes (handle page crossing)
+    if (check_page_cross && ((base & 0XFF00) != (addr & 0xFF00)))
+        cycles_until_cpu_boundary += 1;
+
+    return addr;
+}
+
+uint16_t CPU::addr_absy(bool check_page_cross = false) { // absolute indexed, y
+    uint16_t base = addr_abs();
+    uint16_t addr = base + Y;
+
+    // check high byte for changes (handle page crossing)
+    if (check_page_cross && ((base & 0XFF00) != (addr & 0xFF00)))
+        cycles_until_cpu_boundary += 1;
+
+    return addr;
+}
+
+uint16_t CPU::addr_indx() { // indirect, x
+    // take byte, add x, and add 0xFF to keep ptr within zero page (prevents wrap bug)
+    uint8_t ptr = (addr_zp() + X) & 0xFF;
+
+    // read 2 bytes from zero page where ptr is looking
+    uint8_t low = mem->read(ptr);
+    uint8_t high = mem->read((ptr + 1) & 0xFF);
+
+    // return address
+    return (high << 8) | low;
+}
+
+uint16_t CPU::addr_indy(bool check_page_cross = false) { // indirect, y
+    // take byte, add x, and add 0xFF to keep ptr within zero page (prevents wrap bug)
+    uint8_t ptr = addr_zp();
+
+    // read 2 bytes from zero page where ptr is looking
+    uint8_t low = mem->read(ptr);
+    uint8_t high = mem->read((ptr + 1) & 0xFF);
+
+    // create base address and add y for final address
+    uint16_t base = (high << 8) | low;
+    uint16_t addr = base + Y;
+
+    // check high byte for changes (handle page crossing)
+    if (check_page_cross && ((base & 0XFF00) != (addr & 0xFF00)))
+        cycles_until_cpu_boundary += 1;
+
+    return addr;
+}
+
 void CPU::init_state() {
     A = X = Y = 0;
     S = 0xFD;
@@ -662,7 +734,7 @@ int CPU::step() {
 
             // adjust timing
             cycles_until_cpu_boundary += 7;
-            
+
             break;
         }
         

--- a/src/nes/cpu.cpp
+++ b/src/nes/cpu.cpp
@@ -209,6 +209,86 @@ int CPU::step() {
             cycles_until_cpu_boundary += 2;
             break;
         }
+        case 0x30: { // bmi rel
+            // fetch offset
+            int8_t off = (int8_t)fetch8();
+            // base timing
+            cycles_until_cpu_boundary += 2;
+
+            // check status and n_flag
+            if (P & N_FLAG) {
+                // execute branch (1 cycle)
+                uint16_t old_pc = PC;
+                PC += off;
+                cycles_until_cpu_boundary += 1;
+                
+                // handle page crossing
+                if ((old_pc & 0xFF00) != (PC & 0xFF00)) // old and new pc are on different pages
+                    cycles_until_cpu_boundary += 1; // takes additional cycle if true
+            }
+
+            break;
+        }
+        case 0x50: { // bvc rel
+            // fetch offset
+            int8_t off = (int8_t)fetch8();
+            // base timing
+            cycles_until_cpu_boundary += 2;
+
+            // check status and v_flag (if overflow flag is clear)
+            if (!(P & V_FLAG)) {
+                // execute branch (1 cycle)
+                uint16_t old_pc = PC;
+                PC += off;
+                cycles_until_cpu_boundary += 1;
+                
+                // handle page crossing
+                if ((old_pc & 0xFF00) != (PC & 0xFF00)) // old and new pc are on different pages
+                    cycles_until_cpu_boundary += 1; // takes additional cycle if true
+            }
+
+            break;
+        }
+        case 0x70: { // bvs rel
+            // fetch offset
+            int8_t off = (int8_t)fetch8();
+            // base timing
+            cycles_until_cpu_boundary += 2;
+
+            // check status and v_flag
+            if ((P & V_FLAG)) {
+                // execute branch (1 cycle)
+                uint16_t old_pc = PC;
+                PC += off;
+                cycles_until_cpu_boundary += 1;
+                
+                // handle page crossing
+                if ((old_pc & 0xFF00) != (PC & 0xFF00)) // old and new pc are on different pages
+                    cycles_until_cpu_boundary += 1; // takes additional cycle if true
+            }
+
+            break;
+        }
+        case 0x90: { // bcc rel
+            // fetch offset
+            int8_t off = (int8_t)fetch8();
+            // base timing
+            cycles_until_cpu_boundary += 2;
+
+            // check status and c_flag (if carry flag is 0)
+            if (!(P & C_FLAG)) {
+                // execute branch (1 cycle)
+                uint16_t old_pc = PC;
+                PC += off;
+                cycles_until_cpu_boundary += 1;
+                
+                // handle page crossing
+                if ((old_pc & 0xFF00) != (PC & 0xFF00)) // old and new pc are on different pages
+                    cycles_until_cpu_boundary += 1; // takes additional cycle if true
+            }
+
+            break;
+        }
         case 0xD0: { // BNE rel
             int8_t off = (int8_t)fetch8();
             bool Z = (P & Z_FLAG) != 0;

--- a/src/nes/cpu.cpp
+++ b/src/nes/cpu.cpp
@@ -642,6 +642,32 @@ int CPU::step() {
             break;
         }
 
+        // ---- Interrupts ----
+        case 0x00: { // brk - force interrupt
+            // increment pc by 1 to prevent rti from executing brk in infinite loop
+            PC++;
+
+            // push pc high byte (8-15)
+            push((PC >> 8) & 0xFF);
+            // push pc low byte (0-7)
+            push(PC & 0xFF);
+            // push status reg
+            push(P | B_FLAG | U_FLAG);
+
+            // set i_flag to prevent nesting interrupts
+            P |= I_FLAG;
+
+            // load new pc from $FFFE (irq / brk vector)
+            PC = mem->read(0xFFFE);
+
+            // adjust timing
+            cycles_until_cpu_boundary += 7;
+            
+            break;
+        }
+        
+        // rti already implemented
+
         default:
             std::fprintf(stderr,
                          "[cpu] UNIMPL opcode=%02X at PC=%04X  A=%02X X=%02X Y=%02X P=%02X S=%02X\n",


### PR DESCRIPTION
Defined and implemented the following addressing mode helper functions:
- addr_abs
- addr_zp
- addr_zpx
- addr_zpy
- addr_absx
- addr_absy
- addr_indx
- addr_indy

The helper functions addr_abs and addr_zp are not 100% necessary, but help with knowing why fetch16 and fetch8 may be called. The next step would be to go through and use these functions where necessary in any opcode case that is already implemented (i.e., the loads opcodes). I figured this could be a separate task to be implemented once this review is done.