### PR TITLE
Fix APU and PPU flag and counter wiring bugs

### DIFF
--- a/include/nes/apu.hpp
+++ b/include/nes/apu.hpp
@@ -235,6 +235,7 @@ class DeltaModulationChannel {
 public:
     void write_register(uint8_t reg, uint8_t value);
     void clock_timer();
+    void clock_memory_reader();
     uint8_t output() const;
     void reset();
 
@@ -281,7 +282,7 @@ private:
 
     bool fetch_sample_byte();
     void clock_output_unit();
-    void clock_memory_reader();
+
 
     // Compute the CPU address from the raw $4012 value.
     static uint16_t decode_address(uint8_t raw) {

--- a/include/nes/ppu.hpp
+++ b/include/nes/ppu.hpp
@@ -102,6 +102,9 @@ namespace nes
 
         void reset();
         void clear(int cycle);
+        void tick();
+        bool is_sprite_zero(int index);
+        uint8_t get_pixel(int index);
         bool intersects(int scanline, uint8_t y);
         void evaluate(int scanline, int cycle);
         void fetch(int scanline, int cycle);
@@ -111,6 +114,9 @@ namespace nes
         static uint8_t maybe_flipped_h(uint8_t attributes, uint8_t byte);
         static bool flip_vertical(uint8_t attributes);
         uint16_t compute_pattern_address(int scanline, uint8_t y, uint8_t tile, uint8_t attr);
+        int secondary_count = 0; // # of sprites in secondary oam
+        // from: https://setsideb.com/behind-the-code-about-the-nes-sprite-capabilities
+        uint8_t spr_x[8]{}, spr_attr[8]{};
 
        static constexpr uint8_t reverse_table[256] = {
             0x00, 0x80, 0x40, 0xC0, 0x20, 0xA0, 0x60, 0xE0,
@@ -160,13 +166,11 @@ namespace nes
         // able to display them.
         // sprite shift registers
         uint8_t spr_shift_low[8]{}, spr_shift_high[8]{};
-        uint8_t spr_x[8]{}, spr_attr[8]{};
         uint8_t spr_oam_index[8]{};
         uint16_t spr_pattern_addr[8]{}; // pattern address for this scanline’s sprites
 
         // secondary OAM working set for the current scanline
         uint8_t secondary_oam[32] = {}; // 8 sprites * 4 bytes
-        int secondary_count = 0; // # of sprites in secondary oam
 
         // need a way to index the OAM sprites, incremented each evaluation step, 0-63
         // "which primary OAM sprite is being tested against this scanline"

--- a/src/nes/apu.cpp
+++ b/src/nes/apu.cpp
@@ -661,6 +661,7 @@ void APU::step()
         pulse2.clock_timer();
         noise.clock_timer();
         dmc.clock_timer();
+        dmc.clock_memory_reader();
     }
 }
 

--- a/src/nes/console.cpp
+++ b/src/nes/console.cpp
@@ -107,6 +107,12 @@ void console::step(cycle_t stepcount) {
         for (int i = 0; i < CPU_TO_PPU; i++) { ppu.step(); }
         apu.step(); // step one APU to one CPU here. APU handles its own timing
 
+        // skip cpu execution for however many stall cycles are pending
+        while (apu.dmc.pending_stall_cycles > 0 && master_cycle_count < target) {
+            master_cycle_count++;
+            apu.dmc.pending_stall_cycles--;
+        }
+
         // check NMI and IRQ
         if (ppu.nmi_pending) {
             ppu.nmi_pending = false;

--- a/src/nes/ppu.cpp
+++ b/src/nes/ppu.cpp
@@ -76,11 +76,68 @@ namespace nes {
         if (timing.is_visible_scanline() && timing.is_visible_cycle()) {
             uint32_t final_pixel_color = 0xFF000000; // Default to black
 
-            if (background_rendering_flag) {
+            if (background_rendering_flag)
+            {
                 uint8_t bg_pixel = bg.get_pixel();
                 uint16_t palette_addr = 0x3F00 + bg_pixel;
                 uint8_t nes_color_index = ppu_bus_read(palette_addr) & 0x3F;
                 final_pixel_color = NES_SYSTEM_PALETTE[nes_color_index];
+
+                // Sprite 0 hit is detected when the first sprite overlaps a
+                // non-transparent background pixel during rendering.
+                // from https://www.nesdev.org/wiki/PPU_registers#Sprite_0_hit_flag
+                // and https://www.nesdev.org/wiki/PPU_rendering#Visible_scanlines_(0-239)
+                // sprite zero hit detection against non-transparent bg pixel
+                // only happens during visible scanlines so background draws first
+                // and sprite 0 draws on top, but if both pixels are opaque, set the flag
+                if (!sprite_zero_hit_flag && sprite_rendering_flag) {
+                    if (sprites.secondary_count > 0 && sprites.is_sprite_zero(0)) {
+                        uint8_t spr_pixel = sprites.get_pixel(0);
+                        uint8_t bg_bits = bg_pixel & 0x03;
+                        int x_coord = timing.cycle() - 1;
+
+                        if (spr_pixel != 0 && bg_bits != 0 && x_coord != 255) {
+                            // no hit in leftmost 8 pixels if either clipping flag is clear
+                            if (x_coord >= 8 || (leftmost_background_flag && leftmost_sprite_flag)) {
+                                sprite_zero_hit_flag = true;
+                            }
+                        }
+                    }
+                }
+
+                // time to figure out what the color of this visible pixel by evaluating all the sprites
+                // against the background to find the first foreground sprite that's not tansparent and then
+                // set this pixel to that color. if we have no such sprites, use the bg_pixel's color because
+                // there are no sprites that are eclipsing the background.
+                if (sprite_rendering_flag) {
+                    // loop over all sprites (up to 32 in secondary_count)
+                    for (int i = 0; i < sprites.secondary_count; i++) {
+                        // skip sprites that we haven't gotten to yet on this scanline (they are to the right)
+                        if (sprites.spr_x[i] != 0) continue;
+
+                        // get current sprites bits from the shift register
+                        uint8_t spr_pixel = sprites.get_pixel(i);
+
+                        // but skip transparent pixels
+                        if (spr_pixel == 0) continue;
+
+                        // bit 5 tells us if sprite is foreground or behind background
+                        bool behind_bg = (sprites.spr_attr[i] & 0x20) != 0;
+
+                        // lookup sprite palette set our pixel's color
+                        uint8_t palette_index = (sprites.spr_attr[i] & 0x03);
+                        uint16_t palette_addr = 0x3F10 + (palette_index * 4) + spr_pixel;
+                        uint8_t nes_color_index = ppu_bus_read(palette_addr) & 0x3F;
+
+                        // draw sprite if it's in front, or if background pixel is transparent
+                        uint8_t bg_bits = bg_pixel & 0x03;
+                        if (!behind_bg || bg_bits == 0) {
+                            final_pixel_color = NES_SYSTEM_PALETTE[nes_color_index];
+                        }
+                        break; // the first non-transparent sprite wins the my-pixel-is-front game.
+                        // we still exit here if the current sprite is behind the background. that's how NES does it.
+                    }
+                }
             }
 
             int x_coord = timing.cycle() - 1;
@@ -129,17 +186,26 @@ namespace nes {
         // ========================================================
         // 3. SPRITE EVALUATION
         // ========================================================
-        if (timing.is_visible_scanline()) {
+        if (timing.is_visible_scanline())
+        {
             if (timing.is_start_of_scanline()) {
                 sprites.begin_scanline(timing.scanline());
             }
             else if (timing.is_sprite_clear_cycle()) {
                 sprites.clear(timing.cycle());
             }
-            else if (timing.is_sprite_evaluation_cycle()) {
+            else if (timing.is_sprite_evaluation_cycle())
+            {
                 sprites.evaluate(timing.scanline(), timing.cycle());
+
+                if (timing.cycle() == 256 && timing.is_visible_scanline())
+                {
+                    if (sprites.overflow())
+                        sprite_overflow_flag = true;
+                }
             }
-            else if (timing.is_sprite_fetch_cycle()) {
+            else if (timing.is_sprite_fetch_cycle())
+            {
                 sprites.fetch(timing.scanline(), timing.cycle());
             }
         }
@@ -281,6 +347,11 @@ namespace nes {
                 sprite_size_flag                        = (value & 0x20) != 0;
                 ppu_master_slave_flag                   = (value & 0x40) != 0;
                 vblank_nmi_flag                         = (value & 0x80) != 0;
+
+                // from: https://www.nesdev.org/wiki/NMI#Operation
+                // NMI edge detect: if vblank is active and NMI enable just turned on, fire immediately
+                if (vblank_nmi_flag && vblank_flag)
+                    nmi_pending = true;
 
                 // temp vram t bits 11-10 are for nametable select and come from PPUCTRL 1-0
                 t = (t & 0xF3FF) | ((value & 0x03) << 10);
@@ -614,6 +685,22 @@ namespace nes {
         overflow_ = false;
     }
 
+    // https://www.nesdev.org/wiki/PPU_rendering#Drawing_overview
+    void SpritePipeline::tick()
+    {
+        // for each active sprite
+        for (int i = 0; i < secondary_count; i++) {
+            // if its x counter is still counting down, decrement it
+            if (spr_x[i] > 0) {
+                spr_x[i]--;
+            } else {
+                // once it hits 0 shart shifting the pattern data
+                spr_shift_low[i]  <<= 1;
+                spr_shift_high[i] <<= 1;
+            }
+        }
+    }
+
     // clear 1 byte of secondary oam
     void SpritePipeline::clear(int cycle)
     {
@@ -630,6 +717,17 @@ namespace nes {
     {
         int sprite_height = ppu.sprite_size_flag ? 16 : 8;
         return (scanline >= top) && (scanline < top + sprite_height);
+    }
+
+    bool SpritePipeline::is_sprite_zero(int index) {
+        return spr_oam_index[index] == 0;
+    }
+
+    // get a sprite's pixel bits in lohi order to check for 0 hit
+    uint8_t SpritePipeline::get_pixel(int index) {
+        uint8_t lo = (spr_shift_low[index]  & 0x80) ? 1 : 0;
+        uint8_t hi = (spr_shift_high[index] & 0x80) ? 2 : 0;
+        return lo | hi;
     }
 
     // there are 64 sprites, each is 4-bytes: x, tile, attr, y


### PR DESCRIPTION
And close two big sprite implementation gaps: 0 hit and actually drawing sprites (yeah).

Attempting to close leftover work items from PPU and APU implementations. Required moving some fields to public from private.  

There shouldn't be any more  large gaps but there are surely some bugs left to find.

