### PR TITLE
Update Makefile to handle a ROM parameter for passing in a valid ROM …

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,12 +8,13 @@ build:
 	cmake --build $(BUILD_DIR) -j
 
 run: build
+	@test -n "$(ROM)" || (echo 'Usage: make run ROM=/path/to/game.nes' && exit 1)
 	@if [ -x "$(BUILD_DIR)/nes_emu" ]; then \
-	  "$(BUILD_DIR)/nes_emu"; \
+	  "$(BUILD_DIR)/nes_emu" "$(ROM)"; \
 	elif [ -x "$(BUILD_DIR)/src/nes_emu" ]; then \
-	  "$(BUILD_DIR)/src/nes_emu"; \
+	  "$(BUILD_DIR)/src/nes_emu" "$(ROM)"; \
 	elif [ -x "$(BUILD_DIR)/Release/nes_emu.exe" ]; then \
-	  "$(BUILD_DIR)/Release/nes_emu.exe"; \
+	  "$(BUILD_DIR)/Release/nes_emu.exe" "$(ROM)"; \
 	else \
 	  echo "nes_emu binary not found."; exit 1; \
 	fi


### PR DESCRIPTION
…name for "make run ROM=<path to rom>"

Prior Makefile was not executing arbitrary additional arguments as valid ROM names but instead as additional build targets.