### PR TITLE
Implemented Mapper 3 (CNROM) Support

### DIFF
--- a/include/nes/mapper/mapper_002.hpp
+++ b/include/nes/mapper/mapper_002.hpp
@@ -1,0 +1,29 @@
+#pragma once
+#include "mapper.hpp"
+
+namespace nes {
+
+    class Mapper_002 : public Mapper {
+
+        public:
+            // constructor
+            Mapper_002(uint16_t prgBanks, uint16_t charBanks);
+            // deconstructor
+            // override acting as safety net if mapper deconstructor is no longer virtual for some reason
+            ~Mapper_002() override = default;
+
+            // interface overrides
+            // cpu mapper read and write
+            bool cpuMapRead(uint16_t addr, uint32_t &mapped_addr, uint8_t &data) override;
+            bool cpuMapWrite(uint16_t addr, uint32_t &mapped_addr, uint8_t data) override;
+            // ppu mapper read and write
+            bool ppuMapRead(uint16_t addr, uint32_t &mapped_addr) override;
+            bool ppuMapWrite(uint16_t addr, uint32_t &mapped_addr) override;
+
+        private:
+            uint8_t nSelectedPRGBankLow = 0x00;
+            uint8_t nSelectedPRGBankHigh = 0x00;
+
+    };
+
+} // namespace nes

--- a/include/nes/mapper/mapper_003.hpp
+++ b/include/nes/mapper/mapper_003.hpp
@@ -1,0 +1,28 @@
+#pragma once
+#include "mapper.hpp"
+
+namespace nes {
+
+    class Mapper_003 : public Mapper {
+
+        public:
+            // constructor
+            Mapper_003(uint16_t prgBanks, uint16_t charBanks);
+            // deconstructor
+            // override acting as safety net if mapper deconstructor is no longer virtual for some reason
+            ~Mapper_003() override = default;
+
+            // interface overrides
+            // cpu mapper read and write
+            bool cpuMapRead(uint16_t addr, uint32_t &mapped_addr, uint8_t &data) override;
+            bool cpuMapWrite(uint16_t addr, uint32_t &mapped_addr, uint8_t data) override;
+            // ppu mapper read and write
+            bool ppuMapRead(uint16_t addr, uint32_t &mapped_addr) override;
+            bool ppuMapWrite(uint16_t addr, uint32_t &mapped_addr) override;
+
+        private:
+            uint8_t nSelectedCHRBank = 0x00;
+
+    };
+
+} // namespace nes

--- a/src/nes/mapper/mapper_002.cpp
+++ b/src/nes/mapper/mapper_002.cpp
@@ -1,0 +1,82 @@
+#include "nes/mapper/mapper_002.hpp"
+
+namespace nes {
+
+    // constructor: pass bank counts up to base mapper class
+    Mapper_002::Mapper_002(uint16_t prgBanks, uint16_t chrBanks)
+        // member initialiser using base mapper class
+        : Mapper(prgBanks, chrBanks) {
+            nSelectedPRGBankLow = 0;
+            nSelectedPRGBankHigh = prgBanks - 1;
+        }
+
+        // cpu mapper read
+        // mapper 2 (uxrom) handles prg-rom range $8000-$FFFF
+        bool Mapper_002::cpuMapRead(uint16_t addr, uint32_t &mapped_addr, uint8_t &data) {
+            // check range
+            if (addr >= 0x8000 && addr <= 0xBFFF) {
+                // switchable bank
+                mapped_addr = (nSelectedPRGBankLow * 0x4000) + (addr & 0x3FFF);
+                return true;
+            }
+
+            // check range
+            if (addr >= 0xC000 && addr <= 0xFFFF) {
+                // fixed bank
+                mapped_addr = (nSelectedPRGBankHigh * 0x4000) + (addr & 0x3FFF);
+                return true;
+            }
+
+            // if outside range, don't allow cpu to read
+            return false;
+        }
+
+        // cpu mapper write
+        //mapper 2 (uxrom) uses cpu writes to the rom range to trigger bank switching
+        bool Mapper_002::cpuMapWrite(uint16_t addr, uint32_t &mapped_addr, uint8_t data) {
+            // check range
+            if (addr >= 0x8000 && addr <= 0xFFFF) {
+                // writing to this range will trigger a bank switch
+                // 'data' determines the bank
+                // uxrom usually only uses the lower 4 bits
+                nSelectedPRGBankLow = data & 0x0F;
+            }
+
+            // always return false since there is no writing done
+            return false;
+        }
+
+        // ppu mapper read
+        // mapper 2 (uxrom) handles graphics range $0000-$1FFF
+        bool Mapper_002::ppuMapRead(uint16_t addr, uint32_t &mapped_addr) {
+            // check range
+            if (addr >= 0x0000 && addr <= 0x1FFF) {
+                // mapper 2 (uxrom) uses 1:1 mapping for the ppu
+                mapped_addr = addr;
+                return true;
+            }
+
+            // if outside range, don't allow ppu to read
+            return false;
+        }
+
+        // ppu mapper write
+        // mapper 2 (uxrom) handles graphics range $0000-$1FFF
+        bool Mapper_002::ppuMapWrite(uint16_t addr, uint32_t &mapped_addr) {
+            // check range
+            if (addr >= 0x0000 && addr <= 0x1FFF) {
+                // check if chr-ram is being used
+                if (chrBanks == 0) {
+                    // mapper 2 (uxrom) uses 1:1 mapping for the ppu
+                    mapped_addr = addr;
+                    return true;
+                } else {
+                    // treat as chr-rom and ignore writes
+                    return false;
+                }
+            }
+
+            // if outside range, don't allow ppu to write
+            return false;
+        }
+} // namespace nes

--- a/src/nes/mapper/mapper_003.cpp
+++ b/src/nes/mapper/mapper_003.cpp
@@ -1,0 +1,60 @@
+#include "nes/mapper/mapper_003.hpp"
+
+namespace nes {
+
+    // constructor: pass bank counts up to base mapper class
+    Mapper_003::Mapper_003(uint16_t prgBanks, uint16_t chrBanks)
+        // member initialiser using base mapper class
+        : Mapper(prgBanks, chrBanks) {
+            nSelectedCHRBank = 0;
+        }
+
+        // cpu mapper read
+        // mapper 3 (cnrom) handles prg-rom range $8000-$FFFF
+        bool Mapper_003::cpuMapRead(uint16_t addr, uint32_t &mapped_addr, uint8_t &data) {
+            // check range
+            if (addr >= 0x8000 && addr <= 0xFFFF) {
+                // mirroring logic:
+                // if 1 bank (16 kb), mask with 0x3FFF to repeat data at $C000
+                // if 2 banks (32 kb), mask with 0x7FFF for linear mapping
+                mapped_addr = addr & (prgBanks > 1 ? 0x7FFF : 0x3FFF);
+                return true;
+            }
+
+            // if outside range, don't allow cpu to read
+            return false;
+        }
+
+        // cpu mapper write
+        // mapper 3 (cnrom) does have bank-switching registers
+        bool Mapper_003::cpuMapWrite(uint16_t addr, uint32_t &mapped_addr, uint8_t data) {
+            // check range
+            if (addr >= 0x8000 && addr <= 0xFFFF) {
+                // cnrom supports up to 4 banks
+                nSelectedCHRBank = data & 0x03;
+            }
+
+            // if outside range, don't allow cpu to write
+            return false;
+        }
+
+        // ppu mapper read
+        // mapper 3 (cnrom) handles graphics range $0000-$1FFF
+        bool Mapper_003::ppuMapRead(uint16_t addr, uint32_t &mapped_addr) {
+            // check range
+            if (addr >= 0x0000 && addr <= 0x1FFF) {
+                // map the 8 kb chr bank
+                mapped_addr = (nSelectedCHRBank * 0x2000) + addr;
+                return true;
+            }
+
+            // if outside range, don't allow ppu to read
+            return false;
+        }
+
+        // ppu mapper write
+        // mapper 3 (cnrom) uses chr-rom, so these writes are generally not allowed
+        bool Mapper_003::ppuMapWrite(uint16_t addr, uint32_t &mapped_addr) {
+            return false;
+        }
+} // namespace nes


### PR DESCRIPTION
Added support for Mapper 3 (CNROM). This one handles CHR-ROM switching but follows the logic of NROM. New files include:
- mapper_003.hpp
- mapper_003.cpp

Approval of this PR closes #81.