### PR TITLE
Implemented Mapper 4 (MMC3) Support

### DIFF
--- a/include/nes/mapper/mapper_002.hpp
+++ b/include/nes/mapper/mapper_002.hpp
@@ -1,0 +1,29 @@
+#pragma once
+#include "mapper.hpp"
+
+namespace nes {
+
+    class Mapper_002 : public Mapper {
+
+        public:
+            // constructor
+            Mapper_002(uint16_t prgBanks, uint16_t charBanks);
+            // deconstructor
+            // override acting as safety net if mapper deconstructor is no longer virtual for some reason
+            ~Mapper_002() override = default;
+
+            // interface overrides
+            // cpu mapper read and write
+            bool cpuMapRead(uint16_t addr, uint32_t &mapped_addr, uint8_t &data) override;
+            bool cpuMapWrite(uint16_t addr, uint32_t &mapped_addr, uint8_t data) override;
+            // ppu mapper read and write
+            bool ppuMapRead(uint16_t addr, uint32_t &mapped_addr) override;
+            bool ppuMapWrite(uint16_t addr, uint32_t &mapped_addr) override;
+
+        private:
+            uint8_t nSelectedPRGBankLow = 0x00;
+            uint8_t nSelectedPRGBankHigh = 0x00;
+
+    };
+
+} // namespace nes

--- a/include/nes/mapper/mapper_003.hpp
+++ b/include/nes/mapper/mapper_003.hpp
@@ -1,0 +1,28 @@
+#pragma once
+#include "mapper.hpp"
+
+namespace nes {
+
+    class Mapper_003 : public Mapper {
+
+        public:
+            // constructor
+            Mapper_003(uint16_t prgBanks, uint16_t charBanks);
+            // deconstructor
+            // override acting as safety net if mapper deconstructor is no longer virtual for some reason
+            ~Mapper_003() override = default;
+
+            // interface overrides
+            // cpu mapper read and write
+            bool cpuMapRead(uint16_t addr, uint32_t &mapped_addr, uint8_t &data) override;
+            bool cpuMapWrite(uint16_t addr, uint32_t &mapped_addr, uint8_t data) override;
+            // ppu mapper read and write
+            bool ppuMapRead(uint16_t addr, uint32_t &mapped_addr) override;
+            bool ppuMapWrite(uint16_t addr, uint32_t &mapped_addr) override;
+
+        private:
+            uint8_t nSelectedCHRBank = 0x00;
+
+    };
+
+} // namespace nes

--- a/include/nes/mapper/mapper_004.hpp
+++ b/include/nes/mapper/mapper_004.hpp
@@ -1,0 +1,55 @@
+#pragma once
+#include "mapper.hpp"
+
+namespace nes {
+
+    class Mapper_004 : public Mapper {
+
+        public:
+            // constructor
+            Mapper_004(uint16_t prgBanks, uint16_t charBanks);
+            // deconstructor
+            // override acting as safety net if mapper deconstructor is no longer virtual for some reason
+            ~Mapper_004() override = default;
+
+            // interface overrides
+            // cpu mapper read and write
+            bool cpuMapRead(uint16_t addr, uint32_t &mapped_addr, uint8_t &data) override;
+            bool cpuMapWrite(uint16_t addr, uint32_t &mapped_addr, uint8_t data) override;
+            // ppu mapper read and write
+            bool ppuMapRead(uint16_t addr, uint32_t &mapped_addr) override;
+            bool ppuMapWrite(uint16_t addr, uint32_t &mapped_addr) override;
+
+            // mapper to cpu interrupt interface
+            bool irqActive();
+            void irqClear();
+            void scanline(); // called by the ppu every scanline
+            uint8_t mirrorMode() override;
+
+        private:
+            // mmc3 uses a target register system
+            uint8_t nTargetRegister = 0x00;
+
+            // control for inversion
+            bool bPRGBankMode = false;
+            bool bCHRInversion = false;
+
+            // internal registers for bank indices
+            uint32_t pRegister[8];
+            uint32_t pPRGBank[4];
+            uint32_t pCHRBank[8];
+
+            // mirroring
+            // 0: vertical | 1: horizontal
+            uint8_t nMirrorMode = 0;
+
+            // irq counter logic
+            bool bIRQActive = false;
+            bool bIRQEnable = false;
+            bool bIRQReload = false;
+            uint16_t nIRQCounter = 0x0000;
+            uint16_t nIRQLatch = 0x0000;
+
+    };
+
+} // namespace nes

--- a/src/nes/mapper/mapper_002.cpp
+++ b/src/nes/mapper/mapper_002.cpp
@@ -1,0 +1,82 @@
+#include "nes/mapper/mapper_002.hpp"
+
+namespace nes {
+
+    // constructor: pass bank counts up to base mapper class
+    Mapper_002::Mapper_002(uint16_t prgBanks, uint16_t chrBanks)
+        // member initialiser using base mapper class
+        : Mapper(prgBanks, chrBanks) {
+            nSelectedPRGBankLow = 0;
+            nSelectedPRGBankHigh = prgBanks - 1;
+        }
+
+        // cpu mapper read
+        // mapper 2 (uxrom) handles prg-rom range $8000-$FFFF
+        bool Mapper_002::cpuMapRead(uint16_t addr, uint32_t &mapped_addr, uint8_t &data) {
+            // check range
+            if (addr >= 0x8000 && addr <= 0xBFFF) {
+                // switchable bank
+                mapped_addr = (nSelectedPRGBankLow * 0x4000) + (addr & 0x3FFF);
+                return true;
+            }
+
+            // check range
+            if (addr >= 0xC000 && addr <= 0xFFFF) {
+                // fixed bank
+                mapped_addr = (nSelectedPRGBankHigh * 0x4000) + (addr & 0x3FFF);
+                return true;
+            }
+
+            // if outside range, don't allow cpu to read
+            return false;
+        }
+
+        // cpu mapper write
+        //mapper 2 (uxrom) uses cpu writes to the rom range to trigger bank switching
+        bool Mapper_002::cpuMapWrite(uint16_t addr, uint32_t &mapped_addr, uint8_t data) {
+            // check range
+            if (addr >= 0x8000 && addr <= 0xFFFF) {
+                // writing to this range will trigger a bank switch
+                // 'data' determines the bank
+                // uxrom usually only uses the lower 4 bits
+                nSelectedPRGBankLow = data & 0x0F;
+            }
+
+            // always return false since there is no writing done
+            return false;
+        }
+
+        // ppu mapper read
+        // mapper 2 (uxrom) handles graphics range $0000-$1FFF
+        bool Mapper_002::ppuMapRead(uint16_t addr, uint32_t &mapped_addr) {
+            // check range
+            if (addr >= 0x0000 && addr <= 0x1FFF) {
+                // mapper 2 (uxrom) uses 1:1 mapping for the ppu
+                mapped_addr = addr;
+                return true;
+            }
+
+            // if outside range, don't allow ppu to read
+            return false;
+        }
+
+        // ppu mapper write
+        // mapper 2 (uxrom) handles graphics range $0000-$1FFF
+        bool Mapper_002::ppuMapWrite(uint16_t addr, uint32_t &mapped_addr) {
+            // check range
+            if (addr >= 0x0000 && addr <= 0x1FFF) {
+                // check if chr-ram is being used
+                if (chrBanks == 0) {
+                    // mapper 2 (uxrom) uses 1:1 mapping for the ppu
+                    mapped_addr = addr;
+                    return true;
+                } else {
+                    // treat as chr-rom and ignore writes
+                    return false;
+                }
+            }
+
+            // if outside range, don't allow ppu to write
+            return false;
+        }
+} // namespace nes

--- a/src/nes/mapper/mapper_003.cpp
+++ b/src/nes/mapper/mapper_003.cpp
@@ -1,0 +1,60 @@
+#include "nes/mapper/mapper_003.hpp"
+
+namespace nes {
+
+    // constructor: pass bank counts up to base mapper class
+    Mapper_003::Mapper_003(uint16_t prgBanks, uint16_t chrBanks)
+        // member initialiser using base mapper class
+        : Mapper(prgBanks, chrBanks) {
+            nSelectedCHRBank = 0;
+        }
+
+        // cpu mapper read
+        // mapper 3 (cnrom) handles prg-rom range $8000-$FFFF
+        bool Mapper_003::cpuMapRead(uint16_t addr, uint32_t &mapped_addr, uint8_t &data) {
+            // check range
+            if (addr >= 0x8000 && addr <= 0xFFFF) {
+                // mirroring logic:
+                // if 1 bank (16 kb), mask with 0x3FFF to repeat data at $C000
+                // if 2 banks (32 kb), mask with 0x7FFF for linear mapping
+                mapped_addr = addr & (prgBanks > 1 ? 0x7FFF : 0x3FFF);
+                return true;
+            }
+
+            // if outside range, don't allow cpu to read
+            return false;
+        }
+
+        // cpu mapper write
+        // mapper 3 (cnrom) does have bank-switching registers
+        bool Mapper_003::cpuMapWrite(uint16_t addr, uint32_t &mapped_addr, uint8_t data) {
+            // check range
+            if (addr >= 0x8000 && addr <= 0xFFFF) {
+                // cnrom supports up to 4 banks
+                nSelectedCHRBank = data & 0x03;
+            }
+
+            // if outside range, don't allow cpu to write
+            return false;
+        }
+
+        // ppu mapper read
+        // mapper 3 (cnrom) handles graphics range $0000-$1FFF
+        bool Mapper_003::ppuMapRead(uint16_t addr, uint32_t &mapped_addr) {
+            // check range
+            if (addr >= 0x0000 && addr <= 0x1FFF) {
+                // map the 8 kb chr bank
+                mapped_addr = (nSelectedCHRBank * 0x2000) + addr;
+                return true;
+            }
+
+            // if outside range, don't allow ppu to read
+            return false;
+        }
+
+        // ppu mapper write
+        // mapper 3 (cnrom) uses chr-rom, so these writes are generally not allowed
+        bool Mapper_003::ppuMapWrite(uint16_t addr, uint32_t &mapped_addr) {
+            return false;
+        }
+} // namespace nes

--- a/src/nes/mapper/mapper_004.cpp
+++ b/src/nes/mapper/mapper_004.cpp
@@ -1,0 +1,185 @@
+#include "nes/mapper/mapper_004.hpp"
+
+namespace nes {
+
+    // constructor: pass bank counts up to base mapper class
+    Mapper_004::Mapper_004(uint16_t prgBanks, uint16_t chrBanks)
+        // member initialiser using base mapper class
+        : Mapper(prgBanks, chrBanks) {
+            // initialise registers
+            for (int i = 0; i < 8; i++)
+                pRegister[i] = 0;
+
+            // setup for fixed prg banks (last two)
+            pPRGBank[2] = (prgBanks *  2 - 2) * 0x2000;
+            pPRGBank[3] = (prgBanks *  2 - 1) * 0x2000;
+        }
+
+        // cpu mapper read
+        // mapper 4 (mmc3) handles prg-rom range $8000-$FFFF
+        bool Mapper_004::cpuMapRead(uint16_t addr, uint32_t &mapped_addr, uint8_t &data) {
+            // check range
+            if (addr >= 0x8000 && addr <= 0xFFFF) {
+                // divide range into 4 slots of 8 kb (0x2000)
+                int slot = (addr - 0x8000) / 0x2000;
+                mapped_addr = pPRGBank[slot] + (addr & 0x1FFF);
+                return true;
+            }
+
+            // if outside range, don't allow cpu to read
+            return false;
+        }
+
+        // cpu mapper write
+        // mapper 4 (mmc3) handles complex bank switching
+        bool Mapper_004::cpuMapWrite(uint16_t addr, uint32_t &mapped_addr, uint8_t data) {
+            // check range
+            if (addr >= 0x8000 && addr <= 0x9FFF) {
+                // check address parity
+                if (!(addr & 0x0001)) {
+                    // if even address: bank select
+                    nTargetRegister = data & 0x07;
+                    bPRGBankMode = data & 0x40;
+                    bCHRInversion = data & 0x80;
+                } else { 
+                    // if odd address: bank data
+                    pRegister[nTargetRegister] = data;
+                }
+
+                // update chr banks
+                // determine offset
+                int offset = bCHRInversion ? 4 : 0;
+
+                // 2 kb banks (r0 & r1)
+                pCHRBank[(0 + offset) % 8] = (pRegister[0] & 0xFE) * 0x0400;
+                pCHRBank[(1 + offset) % 8] = (pRegister[0] | 0x01) * 0x0400;
+                pCHRBank[(2 + offset) % 8] = (pRegister[1] & 0xFE) * 0x0400;
+                pCHRBank[(3 + offset) % 8] = (pRegister[1] | 0x01) * 0x0400;
+
+                // 1 kb banks (r2 - r5)
+                pCHRBank[(4 + offset) % 8] = pRegister[2] * 0x0400;
+                pCHRBank[(5 + offset) % 8] = pRegister[3] * 0x0400;
+                pCHRBank[(6 + offset) % 8] = pRegister[4] * 0x0400;
+                pCHRBank[(7 + offset) % 8] = pRegister[5] * 0x0400;
+
+                // update prg banks
+                if (bPRGBankMode) {
+                    pPRGBank[0] = (prgBanks * 2 - 2) * 0x2000;
+                    pPRGBank[2] = pRegister[6] * 0x2000;
+                } else {
+                    pPRGBank[0] = pRegister[6] * 0x2000;
+                    pPRGBank[2] = (prgBanks * 2 - 2) * 0x2000;
+                }
+                pPRGBank[1] = pRegister[7] * 0x2000;
+                
+                return false;
+            }
+
+            // check range
+            if (addr >= 0xA000 && addr <= 0xBFFF) {
+                // check address parity
+                if (!(addr & 0x0001)) {
+                    // mirroring ($A000)
+                    // 0: vertical | 1: horizontal
+                    nMirrorMode = (data & 0x01);
+                }
+
+                return false;
+            }
+
+            // check range
+            if (addr >= 0xC000 && addr <= 0xDFFF) {
+                // check address parity
+                if (!(addr & 0x0001)) {
+                    // irq latch ($C000)
+                    nIRQLatch = data;
+                } else {
+                    // irq reload ($C001)
+                    bIRQReload = true;
+                }
+
+                return false;
+            }
+
+            // check range
+            if (addr >= 0xE000 && addr <= 0xFFFF) {
+                // check address parity
+                if (!(addr & 0x0001)) {
+                    // irq disable ($E000)
+                    bIRQEnable = false;
+                    bIRQActive = false;
+                } else {
+                    // irq enable ($E001)
+                    bIRQEnable = true;
+                }
+
+                return false;
+            }
+
+            // if outside range, don't allow cpu to write
+            return false;
+        }
+
+        // ppu mapper read
+        // mapper 4 (mmc3) handles graphics range $0000-$1FFF
+        bool Mapper_004::ppuMapRead(uint16_t addr, uint32_t &mapped_addr) {
+            // check range
+            if (addr >= 0x0000 && addr <= 0x1FFF) {
+                // divide range into 8 slots of 1 kb (0x0400)
+                int slot = addr / 0x0400;
+                mapped_addr = pCHRBank[slot] + (addr & 0x03FF);
+                return true;
+            }
+
+            // if outside range, don't allow ppu to read
+            return false;
+        }
+
+        // ppu mapper write
+        // mapper 4 (mmc3) uses chr-ram to write if no chr-rom is present
+        bool Mapper_004::ppuMapWrite(uint16_t addr, uint32_t &mapped_addr) {
+            // check range
+            if (addr >= 0x0000 && addr <= 0x1FFF) {
+                // chr-ram check
+                if (chrBanks == 0) {
+                    mapped_addr = addr;
+                    return true;
+				}
+            }
+
+            // if outside range, don't allow ppu to write
+            return false;
+        }
+
+        // checks if mapper is requesting an interrupt
+        bool Mapper_004::irqActive() {
+            return bIRQActive;
+        }
+
+        // acknowledges and clears mapper's interrupt request
+        void Mapper_004::irqClear() {
+            bIRQActive = false;
+        }
+
+        // advances the irq counter
+        void Mapper_004::scanline() {
+            // checks if counter is done or reload is set
+            if (nIRQCounter == 0 || bIRQReload) {
+                nIRQCounter = nIRQLatch;
+                bIRQReload = false;
+            } else {
+                nIRQCounter--;
+            }
+
+            // checks if counter is done and irq is enabled
+            if (nIRQCounter == 0 && bIRQEnable) {
+                // trigger an irq to the cpu
+                bIRQActive = true;
+            }
+        }
+
+        // checks the current hardware mirroring mode
+        uint8_t Mapper_004::mirrorMode() {
+            return nMirrorMode;
+        }
+} // namespace nes


### PR DESCRIPTION
Added support for Mapper 4 (MMC3). This one also includes setup for mirroring and the IRQ system to help the PPU. New files include:

- mapper_004.hpp
- mapper_004.cpp

Approval of this PR closes #79 