### PR TITLE
Test suit refactor

### DIFF
--- a/include/nes/mapper/mapper_000.hpp
+++ b/include/nes/mapper/mapper_000.hpp
@@ -7,7 +7,7 @@ namespace nes {
 
         public:
             // constructor
-            Mapper_000(uint16_t prgBanks, uint16_t charBanks);
+            Mapper_000(uint16_t prgBanks, uint16_t charBanks, bool is_chr_ram = false);
             // deconstructor
             // override acting as safety net if mapper deconstructor is no longer virtual for some reason
             ~Mapper_000() override = default;

--- a/src/nes/ROM.cpp
+++ b/src/nes/ROM.cpp
@@ -86,7 +86,7 @@ namespace nes {
 				bool is_chr_ram = (CHR_ROM_size == 0);
                 uint16_t mapper_chr_banks = (CHR_ROM_size == 0) ? 1 : CHR_ROM_size;
                 // pass info to mapper 0
-                mapper_ptr = std::make_shared<Mapper_000>(PRG_ROM_size, mapper_chr_banks);
+                mapper_ptr = std::make_shared<Mapper_000>(PRG_ROM_size, mapper_chr_banks, is_chr_ram);
                 break;
             }
 

--- a/src/nes/mapper/mapper_000.cpp
+++ b/src/nes/mapper/mapper_000.cpp
@@ -3,9 +3,9 @@
 namespace nes {
 
     // constructor: pass bank counts up to base mapper class
-    Mapper_000::Mapper_000(uint16_t prgBanks, uint16_t chrBanks)
+    Mapper_000::Mapper_000(uint16_t prgBanks, uint16_t chrBanks, bool is_chr_ram)
         // member initialiser using base mapper class
-        : Mapper(prgBanks, chrBanks) {}
+        : Mapper(prgBanks, chrBanks), is_chr_ram(is_chr_ram) {}
 
         // cpu mapper read
         // mapper 0 (nrom) handles prg-rom range $8000-$FFFF
@@ -26,16 +26,7 @@ namespace nes {
         // cpu mapper write
         // mapper 0 (nrom) doesn't have bank-switching registers (it's a simple mapper)
         bool Mapper_000::cpuMapWrite(uint16_t addr, uint32_t &mapped_addr, uint8_t data) {
-            // check range
-            if (addr >= 0x8000 && addr <= 0xFFFF) {
-                if (is_chr_ram) {
-                    // if chr ram, allow writes to chr ram area (mapper 0 doesn't have registers, so we can just write to chr ram directly)
-                    mapped_addr = addr & (chrBanks > 1 ? 0x1FFF : 0x0FFF); // mirror chr ram if multiple banks
-                    return true;
-				}
-            }
-
-            // if outside range, don't allow cpu to write
+            // CPU writes in PRG-ROM space are ignored.
             return false;
         }
 
@@ -54,9 +45,13 @@ namespace nes {
         }
 
         // ppu mapper write
-        // mapper 0 (nrom) uses rom for chr (means writes are typically ignored)
+        // mapper 0 (nrom) uses rom for chr unless the cartridge provides chr-ram
         bool Mapper_000::ppuMapWrite(uint16_t addr, uint32_t &mapped_addr) {
-            // don't allow ppu to write to memory cause chr is not being used
+            if (addr >= 0x0000 && addr <= 0x1FFF && is_chr_ram) {
+                mapped_addr = addr;
+                return true;
+            }
+
             return false;
         }
 } // namespace nes

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,42 +1,131 @@
 
 find_package(GTest CONFIG REQUIRED)
-
+include(GoogleTest)
 
 add_executable(opcode_tests
         cpu/opcode_tests.cpp
 )
 target_link_libraries(opcode_tests PRIVATE nes_lib GTest::gtest_main)
+target_include_directories(opcode_tests PRIVATE ${PROJECT_SOURCE_DIR}/tests)
+
+add_executable(cpu_tests
+        cpu/cpu_tests.cpp
+)
+target_link_libraries(cpu_tests PRIVATE nes_lib GTest::gtest_main)
+target_include_directories(cpu_tests PRIVATE ${PROJECT_SOURCE_DIR}/tests)
 
 add_executable(ROM_tests
         ROM/ROM_tests.cpp
 )
 target_link_libraries(ROM_tests PRIVATE nes_lib GTest::gtest_main)
+target_include_directories(ROM_tests PRIVATE ${PROJECT_SOURCE_DIR}/tests)
+
+add_executable(console_tests
+        console/console_tests.cpp
+)
+target_link_libraries(console_tests PRIVATE nes_lib GTest::gtest_main)
+target_include_directories(console_tests PRIVATE ${PROJECT_SOURCE_DIR}/tests)
+
+add_executable(mapper_000_tests
+        mapper/mapper_000_tests.cpp
+)
+target_link_libraries(mapper_000_tests PRIVATE nes_lib GTest::gtest_main)
+target_include_directories(mapper_000_tests PRIVATE ${PROJECT_SOURCE_DIR}/tests)
+
+add_executable(mapper_001_tests
+        mapper/mapper_001_tests.cpp
+)
+target_link_libraries(mapper_001_tests PRIVATE nes_lib GTest::gtest_main)
+target_include_directories(mapper_001_tests PRIVATE ${PROJECT_SOURCE_DIR}/tests)
+
+add_executable(mapper_002_tests
+        mapper/mapper_002_tests.cpp
+)
+target_link_libraries(mapper_002_tests PRIVATE nes_lib GTest::gtest_main)
+target_include_directories(mapper_002_tests PRIVATE ${PROJECT_SOURCE_DIR}/tests)
+
+add_executable(mapper_003_tests
+        mapper/mapper_003_tests.cpp
+)
+target_link_libraries(mapper_003_tests PRIVATE nes_lib GTest::gtest_main)
+target_include_directories(mapper_003_tests PRIVATE ${PROJECT_SOURCE_DIR}/tests)
+
+add_executable(mapper_004_tests
+        mapper/mapper_004_tests.cpp
+)
+target_link_libraries(mapper_004_tests PRIVATE nes_lib GTest::gtest_main)
+target_include_directories(mapper_004_tests PRIVATE ${PROJECT_SOURCE_DIR}/tests)
+
+add_executable(mapper_005_tests
+        mapper/mapper_005_tests.cpp
+)
+target_link_libraries(mapper_005_tests PRIVATE nes_lib GTest::gtest_main)
+target_include_directories(mapper_005_tests PRIVATE ${PROJECT_SOURCE_DIR}/tests)
+
+add_executable(mapper_007_tests
+        mapper/mapper_007_tests.cpp
+)
+target_link_libraries(mapper_007_tests PRIVATE nes_lib GTest::gtest_main)
+target_include_directories(mapper_007_tests PRIVATE ${PROJECT_SOURCE_DIR}/tests)
 
 add_executable(mem_tests
         mem/mem_test.cpp
 )
-target_link_libraries(mem_tests PRIVATE nes_lib)
-add_test(NAME mem_tests COMMAND mem_tests)
+target_link_libraries(mem_tests PRIVATE nes_lib GTest::gtest_main)
+target_include_directories(mem_tests PRIVATE ${PROJECT_SOURCE_DIR}/tests)
 
 
 add_executable(ppu_tests
         ppu/ppu_test.cpp
 )
-target_link_libraries(ppu_tests PRIVATE nes_lib)
-add_test(NAME ppu_tests COMMAND mem_tests)
+target_link_libraries(ppu_tests PRIVATE nes_lib GTest::gtest_main)
+target_include_directories(ppu_tests PRIVATE ${PROJECT_SOURCE_DIR}/tests)
 
 add_executable(apu_tests
         apu/apu_test.cpp
 )
 target_link_libraries(apu_tests PRIVATE nes_lib GTest::gtest_main)
+target_include_directories(apu_tests PRIVATE ${PROJECT_SOURCE_DIR}/tests)
+
+add_executable(timing_tests
+        timing/timing_tests.cpp
+)
+target_link_libraries(timing_tests PRIVATE nes_lib GTest::gtest_main)
+target_include_directories(timing_tests PRIVATE ${PROJECT_SOURCE_DIR}/tests)
+
+add_executable(ui_tests
+        ui/ui_tests.cpp
+)
+target_link_libraries(ui_tests PRIVATE nes_lib nes_ui GTest::gtest_main)
+target_include_directories(ui_tests PRIVATE ${PROJECT_SOURCE_DIR}/tests)
+
+add_executable(audio_tests
+        ui/audio_tests.cpp
+)
+target_link_libraries(audio_tests PRIVATE nes_lib nes_ui GTest::gtest_main)
+target_include_directories(audio_tests PRIVATE ${PROJECT_SOURCE_DIR}/tests)
 
 add_executable(tests
         test_sanity.cpp
 )
-target_link_libraries(tests PRIVATE nes_lib)
-add_test(NAME sanity_tests COMMAND tests)
+target_link_libraries(tests PRIVATE nes_lib GTest::gtest_main)
+target_include_directories(tests PRIVATE ${PROJECT_SOURCE_DIR}/tests)
 
-include(GoogleTest)
 gtest_discover_tests(opcode_tests)
+gtest_discover_tests(cpu_tests)
 gtest_discover_tests(ROM_tests)
+gtest_discover_tests(console_tests)
+gtest_discover_tests(mapper_000_tests)
+gtest_discover_tests(mapper_001_tests)
+gtest_discover_tests(mapper_002_tests)
+gtest_discover_tests(mapper_003_tests)
+gtest_discover_tests(mapper_004_tests)
+gtest_discover_tests(mapper_005_tests)
+gtest_discover_tests(mapper_007_tests)
+gtest_discover_tests(mem_tests)
+gtest_discover_tests(ppu_tests)
 gtest_discover_tests(apu_tests)
+gtest_discover_tests(timing_tests)
+gtest_discover_tests(ui_tests)
+gtest_discover_tests(audio_tests)
+gtest_discover_tests(tests)

--- a/tests/ROM/ROM_tests.cpp
+++ b/tests/ROM/ROM_tests.cpp
@@ -1,114 +1,54 @@
 #include "nes/ROM.hpp"
+
 #include <gtest/gtest.h>
 
-#include <filesystem>
 #include <string>
-#include <vector>
 
-static std::string find_nestest_rom() {
-    namespace fs = std::filesystem;
+#include "support/test_utils.hpp"
 
-    // - repo root:          ./tests/test_roms/...
-    // - build dir:          ../tests/test_roms/...
-    // - build/tests dir:    ../../tests/test_roms/...
-    const std::vector<std::string> candidates = {
-        "./tests/test_roms/nestest/nestest.nes",
-        "../tests/test_roms/nestest/nestest.nes",
-        "../../tests/test_roms/nestest/nestest.nes",
-    };
+namespace {
 
-    for (const auto& p : candidates) {
-        if (fs::exists(p)) return p;
+class RomFixture : public ::testing::Test {
+protected:
+    void SetUp() override {
+        rom_path = test_support::find_nestest_rom();
+        ASSERT_FALSE(rom_path.empty()) << "Could not locate nestest ROM from current working directory.";
     }
-    return "";
+
+    std::string rom_path;
+};
+
+TEST_F(RomFixture, LoadFromFileSuccess) {
+    nes::ROM rom;
+    EXPECT_TRUE(rom.load_from_file(rom_path.c_str()));
 }
 
-TEST(LOAD, load_from_file_success) {
-    const std::string path = find_nestest_rom();
-    ASSERT_FALSE(path.empty()) << "Could not locate nestest ROM from current working directory.";
-
+TEST_F(RomFixture, ReportsRomMetadata) {
     nes::ROM rom;
-    bool result = rom.load_from_file(path.c_str());
-    EXPECT_EQ(result, true);
-}
+    ASSERT_TRUE(rom.load_from_file(rom_path.c_str()));
 
-TEST(LOAD, prg_size_bytes) {
-    const std::string path = find_nestest_rom();
-    ASSERT_FALSE(path.empty()) << "Could not locate nestest ROM from current working directory.";
-
-    nes::ROM rom;
-    rom.load_from_file(path.c_str());
     EXPECT_EQ(rom.prg_size_bytes(), 16384u);
-}
-
-TEST(LOAD, chr_size_bytes) {
-    const std::string path = find_nestest_rom();
-    ASSERT_FALSE(path.empty()) << "Could not locate nestest ROM from current working directory.";
-
-    nes::ROM rom;
-    rom.load_from_file(path.c_str());
     EXPECT_EQ(rom.chr_size_bytes(), 8192u);
-}
-
-TEST(LOAD, alternate_nametable_layout) {
-    const std::string path = find_nestest_rom();
-    ASSERT_FALSE(path.empty()) << "Could not locate nestest ROM from current working directory.";
-
-    nes::ROM rom;
-    rom.load_from_file(path.c_str());
-    EXPECT_EQ(rom.alternate_nametable_layout(), false);
-}
-
-TEST(LOAD, mapper) {
-    const std::string path = find_nestest_rom();
-    ASSERT_FALSE(path.empty()) << "Could not locate nestest ROM from current working directory.";
-
-    nes::ROM rom;
-    rom.load_from_file(path.c_str());
+    EXPECT_FALSE(rom.alternate_nametable_layout());
     EXPECT_EQ(rom.mapper(), 0u);
+    EXPECT_TRUE(rom.is_loaded());
 }
 
-TEST(LOAD, is_loaded) {
-    const std::string path = find_nestest_rom();
-    ASSERT_FALSE(path.empty()) << "Could not locate nestest ROM from current working directory.";
-
-    nes::ROM rom;
-    rom.load_from_file(path.c_str());
-    EXPECT_EQ(rom.is_loaded(), true);
-}
-
-TEST(RESET, reset_clears_loaded) {
+TEST(ROMResetTest, ClearsLoadedStateAndData) {
     nes::ROM rom;
     rom.reset();
-    EXPECT_EQ(rom.is_loaded(), false);
-}
 
-TEST(RESET, reset_clears_PNG) {
-    nes::ROM rom;
-    rom.reset();
+    EXPECT_FALSE(rom.is_loaded());
     EXPECT_EQ(rom.prg_size_bytes(), 0u);
-}
-
-TEST(RESET, reset_clears_CHR) {
-    nes::ROM rom;
-    rom.reset();
     EXPECT_EQ(rom.chr_size_bytes(), 0u);
-}
-
-TEST(RESET, reset_clears_mapper) {
-    nes::ROM rom;
-    rom.reset();
     EXPECT_EQ(rom.mapper(), 0u);
-}
-
-TEST(RESET, reset_clears_nametable_layout) {
-    nes::ROM rom;
-    rom.reset();
-    EXPECT_EQ(rom.alternate_nametable_layout(), false);
-}
-
-TEST(RESET, reset_clears_data) {
-    nes::ROM rom;
-    rom.reset();
+    EXPECT_FALSE(rom.alternate_nametable_layout());
     EXPECT_EQ(rom.prg_data(), nullptr);
 }
+
+TEST(ROMLoadTest, MissingFileFailsCleanly) {
+    nes::ROM rom;
+    EXPECT_FALSE(rom.load_from_file("/this/path/should/not/exist.nes"));
+}
+
+} // namespace

--- a/tests/ROM/ROM_tests.cpp
+++ b/tests/ROM/ROM_tests.cpp
@@ -1,9 +1,6 @@
 #include "nes/ROM.hpp"
-
 #include <gtest/gtest.h>
-
 #include <string>
-
 #include "support/test_utils.hpp"
 
 namespace {

--- a/tests/apu/apu_test.cpp
+++ b/tests/apu/apu_test.cpp
@@ -272,8 +272,8 @@ TEST(APUTest, APUStatusRegisterRead) {
     // Read status
     uint8_t status = mem.read(0x4015);
     
-    // Bit 0 should be set if pulse 1 length counter > 0
-    EXPECT_TRUE((status & 0x01) != 0 || (status & 0x01) == 0); // Valid either way
+    // Bit 0 should be set once pulse 1 has a loaded length counter.
+    EXPECT_NE(status & 0x01, 0);
 }
 
 TEST(APUTest, APUFrameCounter) {

--- a/tests/console/console_tests.cpp
+++ b/tests/console/console_tests.cpp
@@ -1,0 +1,40 @@
+#include "nes/console.hpp"
+
+#include <gtest/gtest.h>
+
+#include <string>
+
+#include "support/test_utils.hpp"
+
+namespace {
+
+TEST(ConsoleTest, LoadsNestestRomAndStepsInstructions) {
+    console con;
+
+    const std::string rom_path = test_support::find_nestest_rom();
+    ASSERT_FALSE(rom_path.empty()) << "Could not locate nestest.nes";
+    ASSERT_TRUE(con.load_rom(rom_path.c_str()));
+    EXPECT_TRUE(con.rom_loaded());
+
+    const auto before = con.get_cpu_cycles();
+    const int used_cycles = con.step_instruction();
+    EXPECT_GT(used_cycles, 0);
+    EXPECT_GT(con.get_cpu_cycles(), before);
+}
+
+TEST(ConsoleTest, ResetAllClearsLoadedRomAndCycleCounter) {
+    console con;
+
+    const std::string rom_path = test_support::find_nestest_rom();
+    ASSERT_FALSE(rom_path.empty()) << "Could not locate nestest.nes";
+    ASSERT_TRUE(con.load_rom(rom_path.c_str()));
+
+    con.reset_all();
+
+    EXPECT_FALSE(con.rom_loaded());
+    EXPECT_EQ(con.get_cpu_cycles(), 0u);
+    EXPECT_EQ(con.get_mem().get_controller1(), 0u);
+    EXPECT_EQ(con.get_mem().get_controller2(), 0u);
+}
+
+} // namespace

--- a/tests/console/console_tests.cpp
+++ b/tests/console/console_tests.cpp
@@ -1,9 +1,7 @@
 #include "nes/console.hpp"
 
 #include <gtest/gtest.h>
-
 #include <string>
-
 #include "support/test_utils.hpp"
 
 namespace {

--- a/tests/cpu/cpu_tests.cpp
+++ b/tests/cpu/cpu_tests.cpp
@@ -1,0 +1,79 @@
+#include "nes/cpu.hpp"
+#include "nes/mem.hpp"
+#include "nes/ppu.hpp"
+#include "nes/apu.hpp"
+#include "nes/mapper/mapper_000.hpp"
+
+#include <gtest/gtest.h>
+
+#include <array>
+#include <memory>
+
+namespace {
+
+class CpuFixture : public ::testing::Test {
+protected:
+    CpuFixture()
+        : ppu(), apu(), mem(ppu, apu), cpu() {
+        mem.set_mapper(std::make_shared<nes::Mapper_000>(1, 1));
+        cpu.attach_memory(&mem);
+    }
+
+    void load_program(const std::array<uint8_t, 16384>& prg) {
+        mem.map_prg(prg.data(), prg.size());
+        cpu.reset();
+    }
+
+    nes::PPU ppu;
+    nes::APU apu;
+    nes::Memory mem;
+    nes::CPU cpu;
+};
+
+TEST_F(CpuFixture, LookupInstructionReportsKnownMnemonic) {
+    EXPECT_EQ(cpu.lookupInstruction(0x01), "ORA");
+    EXPECT_EQ(cpu.lookupInstruction(0x02), "???");
+}
+
+TEST_F(CpuFixture, ExecutesSimpleProgramAndStoresRegisters) {
+    std::array<uint8_t, 16384> prg{};
+    prg[0x0000] = 0xA9; // LDA #$42
+    prg[0x0001] = 0x42;
+    prg[0x0002] = 0xAA; // TAX
+    prg[0x0003] = 0xE8; // INX
+    prg[0x3FFC] = 0x00;
+    prg[0x3FFD] = 0x80;
+
+    load_program(prg);
+
+    EXPECT_EQ(cpu.pc(), 0x8000);
+    EXPECT_GT(cpu.step(), 0);
+    EXPECT_EQ(cpu.a(), 0x42);
+    EXPECT_TRUE((cpu.p() & 0x02) == 0);
+
+    EXPECT_GT(cpu.step(), 0);
+    EXPECT_EQ(cpu.x(), 0x42);
+
+    EXPECT_GT(cpu.step(), 0);
+    EXPECT_EQ(cpu.x(), 0x43);
+}
+
+TEST_F(CpuFixture, StoresThroughMemoryBus) {
+    std::array<uint8_t, 16384> prg{};
+    prg[0x0000] = 0xA9; // LDA #$7E
+    prg[0x0001] = 0x7E;
+    prg[0x0002] = 0x8D; // STA $0002
+    prg[0x0003] = 0x02;
+    prg[0x0004] = 0x00;
+    prg[0x0005] = 0x00; // BRK-like stop byte, never executed in this test
+    prg[0x3FFC] = 0x00;
+    prg[0x3FFD] = 0x80;
+
+    load_program(prg);
+
+    EXPECT_GT(cpu.step(), 0);
+    EXPECT_GT(cpu.step(), 0);
+    EXPECT_EQ(mem.read(0x0002), 0x7E);
+}
+
+} // namespace

--- a/tests/mapper/mapper_000_tests.cpp
+++ b/tests/mapper/mapper_000_tests.cpp
@@ -1,0 +1,31 @@
+#include "nes/mapper/mapper_000.hpp"
+
+#include <gtest/gtest.h>
+
+namespace {
+
+TEST(Mapper000Test, MirrorsPrgRomAcrossSingleBank) {
+    nes::Mapper_000 mapper(1, 1);
+    uint32_t mapped_addr = 0;
+    uint8_t data = 0;
+
+    EXPECT_TRUE(mapper.cpuMapRead(0x8000, mapped_addr, data));
+    EXPECT_EQ(mapped_addr, 0x0000u);
+
+    EXPECT_TRUE(mapper.cpuMapRead(0xC000, mapped_addr, data));
+    EXPECT_EQ(mapped_addr, 0x0000u);
+}
+
+TEST(Mapper000Test, SupportsChrRamWritesWhenEnabled) {
+    nes::Mapper_000 mapper(1, 1, true);
+    uint32_t mapped_addr = 0;
+
+    EXPECT_TRUE(mapper.ppuMapWrite(0x0010, mapped_addr));
+    EXPECT_EQ(mapped_addr, 0x0010u);
+    EXPECT_TRUE(mapper.ppuMapWrite(0x1234, mapped_addr));
+    EXPECT_EQ(mapped_addr, 0x1234u);
+
+    EXPECT_FALSE(mapper.cpuMapWrite(0x8000, mapped_addr, 0xAB));
+}
+
+} // namespace

--- a/tests/mapper/mapper_001_tests.cpp
+++ b/tests/mapper/mapper_001_tests.cpp
@@ -1,0 +1,31 @@
+#include "nes/mapper/mapper_001.hpp"
+
+#include <gtest/gtest.h>
+
+namespace {
+
+TEST(Mapper001Test, MapsPrgRamAndFixedUpperBank) {
+    nes::Mapper_001 mapper(2, 1, false);
+    uint32_t mapped_addr = 0;
+    uint8_t data = 0;
+
+    EXPECT_TRUE(mapper.cpuMapWrite(0x6000, mapped_addr, 0x5A));
+    EXPECT_TRUE(mapper.cpuMapRead(0x6000, mapped_addr, data));
+    EXPECT_EQ(mapped_addr, 0xFFFFFFFFu);
+    EXPECT_EQ(data, 0x5Au);
+
+    EXPECT_TRUE(mapper.cpuMapRead(0xC000, mapped_addr, data));
+    EXPECT_EQ(mapped_addr, 0x4000u);
+}
+
+TEST(Mapper001Test, AllowsChrRamWritesWhenConfigured) {
+    nes::Mapper_001 mapper(2, 1, true);
+    uint32_t mapped_addr = 0;
+
+    EXPECT_TRUE(mapper.ppuMapWrite(0x0000, mapped_addr));
+    EXPECT_EQ(mapped_addr, 0x0000u);
+    EXPECT_TRUE(mapper.ppuMapWrite(0x1234, mapped_addr));
+    EXPECT_EQ(mapped_addr, 0x0234u);
+}
+
+} // namespace

--- a/tests/mapper/mapper_002_tests.cpp
+++ b/tests/mapper/mapper_002_tests.cpp
@@ -1,0 +1,20 @@
+#include "nes/mapper/mapper_002.hpp"
+
+#include <gtest/gtest.h>
+
+namespace {
+
+TEST(Mapper002Test, SwitchesLowPrgBankOnCpuWrite) {
+    nes::Mapper_002 mapper(4, 1);
+    uint32_t mapped_addr = 0;
+    uint8_t data = 0;
+
+    EXPECT_TRUE(mapper.cpuMapRead(0x8000, mapped_addr, data));
+    EXPECT_EQ(mapped_addr, 0x0000u);
+
+    EXPECT_FALSE(mapper.cpuMapWrite(0x8000, mapped_addr, 0x02));
+    EXPECT_TRUE(mapper.cpuMapRead(0x8000, mapped_addr, data));
+    EXPECT_EQ(mapped_addr, 0x8000u);
+}
+
+} // namespace

--- a/tests/mapper/mapper_003_tests.cpp
+++ b/tests/mapper/mapper_003_tests.cpp
@@ -1,0 +1,17 @@
+#include "nes/mapper/mapper_003.hpp"
+
+#include <gtest/gtest.h>
+
+namespace {
+
+TEST(Mapper003Test, SelectsChrBankOnCpuWrite) {
+    nes::Mapper_003 mapper(2, 4);
+    uint32_t mapped_addr = 0;
+    uint8_t data = 0;
+
+    EXPECT_FALSE(mapper.cpuMapWrite(0x8000, mapped_addr, 0x03));
+    EXPECT_TRUE(mapper.ppuMapRead(0x0001, mapped_addr));
+    EXPECT_EQ(mapped_addr, 0x6001u);
+}
+
+} // namespace

--- a/tests/mapper/mapper_004_tests.cpp
+++ b/tests/mapper/mapper_004_tests.cpp
@@ -1,0 +1,33 @@
+#include "nes/mapper/mapper_004.hpp"
+
+#include <gtest/gtest.h>
+
+namespace {
+
+TEST(Mapper004Test, UpdatesPrgBanksAndIrqState) {
+    nes::Mapper_004 mapper(4, 2);
+    uint32_t mapped_addr = 0;
+    uint8_t data = 0;
+
+    EXPECT_TRUE(mapper.cpuMapRead(0xC000, mapped_addr, data));
+    EXPECT_EQ(mapped_addr, 0xC000u);
+
+    EXPECT_FALSE(mapper.cpuMapWrite(0x8000, mapped_addr, 0x06));
+    EXPECT_FALSE(mapper.cpuMapWrite(0x8001, mapped_addr, 0x03));
+    EXPECT_TRUE(mapper.cpuMapRead(0x8000, mapped_addr, data));
+    EXPECT_EQ(mapped_addr, 0x6000u);
+
+    EXPECT_FALSE(mapper.cpuMapWrite(0xA000, mapped_addr, 0x01));
+    EXPECT_EQ(mapper.mirrorMode(), 1u);
+
+    EXPECT_FALSE(mapper.cpuMapWrite(0xC000, mapped_addr, 0x01));
+    EXPECT_FALSE(mapper.cpuMapWrite(0xE001, mapped_addr, 0x00));
+    mapper.scanline();
+    EXPECT_FALSE(mapper.irqActive());
+    mapper.scanline();
+    EXPECT_TRUE(mapper.irqActive());
+    mapper.irqClear();
+    EXPECT_FALSE(mapper.irqActive());
+}
+
+} // namespace

--- a/tests/mapper/mapper_005_tests.cpp
+++ b/tests/mapper/mapper_005_tests.cpp
@@ -1,0 +1,28 @@
+#include "nes/mapper/mapper_005.hpp"
+
+#include <gtest/gtest.h>
+
+namespace {
+
+TEST(Mapper005Test, ExRamAndMultiplierWork) {
+    nes::Mapper_005 mapper(8, 8);
+    uint32_t mapped_addr = 0;
+    uint8_t data = 0;
+
+    EXPECT_FALSE(mapper.cpuMapWrite(0x5C10, mapped_addr, 0x77));
+    EXPECT_FALSE(mapper.cpuMapWrite(0x5104, mapped_addr, 0x02));
+    EXPECT_FALSE(mapper.cpuMapRead(0x5C10, mapped_addr, data));
+    EXPECT_EQ(data, 0x77u);
+
+    EXPECT_FALSE(mapper.cpuMapWrite(0x5205, mapped_addr, 12));
+    EXPECT_FALSE(mapper.cpuMapWrite(0x5206, mapped_addr, 34));
+    EXPECT_FALSE(mapper.cpuMapRead(0x5205, mapped_addr, data));
+    EXPECT_EQ(data, 0x98u);
+    EXPECT_FALSE(mapper.cpuMapRead(0x5206, mapped_addr, data));
+    EXPECT_EQ(data, 0x01u);
+
+    EXPECT_FALSE(mapper.cpuMapWrite(0x5105, mapped_addr, 0xAA));
+    EXPECT_EQ(mapper.mirrorMode(), 0xAAu);
+}
+
+} // namespace

--- a/tests/mapper/mapper_007_tests.cpp
+++ b/tests/mapper/mapper_007_tests.cpp
@@ -1,0 +1,21 @@
+#include "nes/mapper/mapper_007.hpp"
+
+#include <gtest/gtest.h>
+
+namespace {
+
+TEST(Mapper007Test, SelectsBankAndMirrorMode) {
+    nes::Mapper_007 mapper(8, 1);
+    uint32_t mapped_addr = 0;
+    uint8_t data = 0;
+
+    EXPECT_FALSE(mapper.cpuMapWrite(0x8000, mapped_addr, 0x13));
+    EXPECT_TRUE(mapper.cpuMapRead(0x8000, mapped_addr, data));
+    EXPECT_EQ(mapped_addr, 0x18000u);
+    EXPECT_EQ(mapper.mirrorMode(), 1u);
+
+    EXPECT_TRUE(mapper.ppuMapRead(0x0123, mapped_addr));
+    EXPECT_EQ(mapped_addr, 0x0123u);
+}
+
+} // namespace

--- a/tests/mapper/mapper_tests.cpp
+++ b/tests/mapper/mapper_tests.cpp
@@ -1,0 +1,145 @@
+#include "nes/mapper/mapper_000.hpp"
+#include "nes/mapper/mapper_001.hpp"
+#include "nes/mapper/mapper_002.hpp"
+#include "nes/mapper/mapper_003.hpp"
+#include "nes/mapper/mapper_004.hpp"
+#include "nes/mapper/mapper_005.hpp"
+#include "nes/mapper/mapper_007.hpp"
+
+#include <gtest/gtest.h>
+
+namespace {
+
+TEST(Mapper000Test, MirrorsPrgRomAcrossSingleBank) {
+    nes::Mapper_000 mapper(1, 1);
+    uint32_t mapped_addr = 0;
+    uint8_t data = 0;
+
+    EXPECT_TRUE(mapper.cpuMapRead(0x8000, mapped_addr, data));
+    EXPECT_EQ(mapped_addr, 0x0000u);
+
+    EXPECT_TRUE(mapper.cpuMapRead(0xC000, mapped_addr, data));
+    EXPECT_EQ(mapped_addr, 0x0000u);
+}
+
+TEST(Mapper000Test, SupportsChrRamWritesWhenEnabled) {
+    nes::Mapper_000 mapper(1, 1, true);
+    uint32_t mapped_addr = 0;
+
+    EXPECT_TRUE(mapper.ppuMapWrite(0x0010, mapped_addr));
+    EXPECT_EQ(mapped_addr, 0x0010u);
+    EXPECT_TRUE(mapper.ppuMapWrite(0x1234, mapped_addr));
+    EXPECT_EQ(mapped_addr, 0x1234u);
+
+    EXPECT_FALSE(mapper.cpuMapWrite(0x8000, mapped_addr, 0xAB));
+}
+
+TEST(Mapper001Test, MapsPrgRamAndFixedUpperBank) {
+    nes::Mapper_001 mapper(2, 1, false);
+    uint32_t mapped_addr = 0;
+    uint8_t data = 0;
+
+    EXPECT_TRUE(mapper.cpuMapWrite(0x6000, mapped_addr, 0x5A));
+    EXPECT_TRUE(mapper.cpuMapRead(0x6000, mapped_addr, data));
+    EXPECT_EQ(mapped_addr, 0xFFFFFFFFu);
+    EXPECT_EQ(data, 0x5Au);
+
+    EXPECT_TRUE(mapper.cpuMapRead(0xC000, mapped_addr, data));
+    EXPECT_EQ(mapped_addr, 0x4000u);
+}
+
+TEST(Mapper001Test, AllowsChrRamWritesWhenConfigured) {
+    nes::Mapper_001 mapper(2, 1, true);
+    uint32_t mapped_addr = 0;
+
+    EXPECT_TRUE(mapper.ppuMapWrite(0x0000, mapped_addr));
+    EXPECT_EQ(mapped_addr, 0x0000u);
+    EXPECT_TRUE(mapper.ppuMapWrite(0x1234, mapped_addr));
+    EXPECT_EQ(mapped_addr, 0x0234u);
+}
+
+TEST(Mapper002Test, SwitchesLowPrgBankOnCpuWrite) {
+    nes::Mapper_002 mapper(4, 1);
+    uint32_t mapped_addr = 0;
+    uint8_t data = 0;
+
+    EXPECT_TRUE(mapper.cpuMapRead(0x8000, mapped_addr, data));
+    EXPECT_EQ(mapped_addr, 0x0000u);
+
+    EXPECT_FALSE(mapper.cpuMapWrite(0x8000, mapped_addr, 0x02));
+    EXPECT_TRUE(mapper.cpuMapRead(0x8000, mapped_addr, data));
+    EXPECT_EQ(mapped_addr, 0x8000u);
+}
+
+TEST(Mapper003Test, SelectsChrBankOnCpuWrite) {
+    nes::Mapper_003 mapper(2, 4);
+    uint32_t mapped_addr = 0;
+    uint8_t data = 0;
+
+    EXPECT_FALSE(mapper.cpuMapWrite(0x8000, mapped_addr, 0x03));
+    EXPECT_TRUE(mapper.ppuMapRead(0x0001, mapped_addr));
+    EXPECT_EQ(mapped_addr, 0x6001u);
+}
+
+TEST(Mapper004Test, UpdatesPrgBanksAndIrqState) {
+    nes::Mapper_004 mapper(4, 2);
+    uint32_t mapped_addr = 0;
+    uint8_t data = 0;
+
+    EXPECT_TRUE(mapper.cpuMapRead(0xC000, mapped_addr, data));
+    EXPECT_EQ(mapped_addr, 0xC000u);
+
+    EXPECT_FALSE(mapper.cpuMapWrite(0x8000, mapped_addr, 0x06));
+    EXPECT_FALSE(mapper.cpuMapWrite(0x8001, mapped_addr, 0x03));
+    EXPECT_TRUE(mapper.cpuMapRead(0x8000, mapped_addr, data));
+    EXPECT_EQ(mapped_addr, 0x6000u);
+
+    EXPECT_FALSE(mapper.cpuMapWrite(0xA000, mapped_addr, 0x01));
+    EXPECT_EQ(mapper.mirrorMode(), 1u);
+
+    EXPECT_FALSE(mapper.cpuMapWrite(0xC000, mapped_addr, 0x01));
+    EXPECT_FALSE(mapper.cpuMapWrite(0xE001, mapped_addr, 0x00));
+    mapper.scanline();
+    EXPECT_FALSE(mapper.irqActive());
+    mapper.scanline();
+    EXPECT_TRUE(mapper.irqActive());
+    mapper.irqClear();
+    EXPECT_FALSE(mapper.irqActive());
+}
+
+TEST(Mapper005Test, ExRamAndMultiplierWork) {
+    nes::Mapper_005 mapper(8, 8);
+    uint32_t mapped_addr = 0;
+    uint8_t data = 0;
+
+    EXPECT_FALSE(mapper.cpuMapWrite(0x5C10, mapped_addr, 0x77));
+    EXPECT_FALSE(mapper.cpuMapWrite(0x5104, mapped_addr, 0x02));
+    EXPECT_FALSE(mapper.cpuMapRead(0x5C10, mapped_addr, data));
+    EXPECT_EQ(data, 0x77u);
+
+    EXPECT_FALSE(mapper.cpuMapWrite(0x5205, mapped_addr, 12));
+    EXPECT_FALSE(mapper.cpuMapWrite(0x5206, mapped_addr, 34));
+    EXPECT_FALSE(mapper.cpuMapRead(0x5205, mapped_addr, data));
+    EXPECT_EQ(data, 0x98u);
+    EXPECT_FALSE(mapper.cpuMapRead(0x5206, mapped_addr, data));
+    EXPECT_EQ(data, 0x01u);
+
+    EXPECT_FALSE(mapper.cpuMapWrite(0x5105, mapped_addr, 0xAA));
+    EXPECT_EQ(mapper.mirrorMode(), 0xAAu);
+}
+
+TEST(Mapper007Test, SelectsBankAndMirrorMode) {
+    nes::Mapper_007 mapper(8, 1);
+    uint32_t mapped_addr = 0;
+    uint8_t data = 0;
+
+    EXPECT_FALSE(mapper.cpuMapWrite(0x8000, mapped_addr, 0x13));
+    EXPECT_TRUE(mapper.cpuMapRead(0x8000, mapped_addr, data));
+    EXPECT_EQ(mapped_addr, 0x18000u);
+    EXPECT_EQ(mapper.mirrorMode(), 1u);
+
+    EXPECT_TRUE(mapper.ppuMapRead(0x0123, mapped_addr));
+    EXPECT_EQ(mapped_addr, 0x0123u);
+}
+
+} // namespace

--- a/tests/mem/mem_test.cpp
+++ b/tests/mem/mem_test.cpp
@@ -1,130 +1,86 @@
-#include <iostream>
-#include <cassert>
-#include "../../include/nes/mem.hpp"
-#include "../../include/nes/ppu.hpp"
-#include "../../include/nes/apu.hpp"
+#include "nes/apu.hpp"
+#include "nes/mem.hpp"
+#include "nes/ppu.hpp"
 
-// A helper to print "PASS" in green
-void log_pass(const char* test_name) {
-    std::cout << "\033[1;32m[PASS] " << test_name << "\033[0m" << std::endl;
-}
+#include <gtest/gtest.h>
 
-void test_ram_functionality() {
+#include <array>
+#include <memory>
+
+#include "nes/mapper/mapper_000.hpp"
+
+namespace {
+
+class BusFixture : public ::testing::Test {
+protected:
+    BusFixture()
+        : ppu(), apu(), mem(ppu, apu) {}
+
     nes::PPU ppu;
     nes::APU apu;
-    nes::Memory mem(ppu, apu);
+    nes::Memory mem;
+};
 
-    // 1. Basic Read/Write
+TEST_F(BusFixture, RamMirrorsAcrossInternalSpace) {
     mem.write(0x0000, 0x42);
-    assert(mem.read(0x0000) == 0x42);
+    EXPECT_EQ(mem.read(0x0000), 0x42);
 
-    // 2. RAM Mirroring
-    // Writing to $0000 should be visible at $0800, $1000, $1800
     mem.write(0x0000, 0xAB);
-    assert(mem.read(0x0800) == 0xAB); // Mirror 1
-    assert(mem.read(0x1000) == 0xAB); // Mirror 2
-    assert(mem.read(0x1800) == 0xAB); // Mirror 3
+    EXPECT_EQ(mem.read(0x0800), 0xAB);
+    EXPECT_EQ(mem.read(0x1000), 0xAB);
+    EXPECT_EQ(mem.read(0x1800), 0xAB);
 
-    // 3. Reverse Mirroring
-    // Writing to a mirror ($1FFF) should affect base ($07FF)
     mem.write(0x1FFF, 0xCD);
-    assert(mem.read(0x07FF) == 0xCD);
-
-    log_pass("RAM Read/Write & Mirroring");
+    EXPECT_EQ(mem.read(0x07FF), 0xCD);
 }
 
-void test_ppu_registers() {
-    nes::PPU ppu;
-    nes::APU apu;
-    nes::Memory mem(ppu, apu);
+TEST_F(BusFixture, PpuRegisterMirroringReadsStatus) {
+    EXPECT_EQ(mem.read(0x2002) & 0x80, 0x80);
 
-    // 1. Test Initial PPU Status ($2002)
-    // Your constructor sets ppu_status = 0x80 (VBlank)
-    uint8_t status = mem.read(0x2002);
-    assert((status & 0x80) == 0x80);
-
-    // 2. Test PPU Register Mirroring
-    // $2000 mirrored every 8 bytes ($2008, $2010, etc.)
-    // Since PPUCTRL ($2000) is usually write-only and returns 0 or open bus,
-    // we can only test that writing to mirrors doesn't crash.
-    // However, we CAN test that reading $2002 works at $200A (Mirror)
-    nes::PPU ppu2;
-    nes::Memory mem2(ppu2, apu);
-    assert((mem2.read(0x200A) & 0x80) == 0x80);
-
-    log_pass("PPU Register Access & Mirroring");
+    nes::PPU mirrored_ppu;
+    nes::APU mirrored_apu;
+    nes::Memory mirrored_mem(mirrored_ppu, mirrored_apu);
+    EXPECT_EQ(mirrored_mem.read(0x200A) & 0x80, 0x80);
 }
 
-void test_bounds_safety() {
-    nes::PPU ppu;
-    nes::APU apu;
-    nes::Memory mem(ppu, apu);
-
-    // Test Open Bus / Unmapped regions
-    // $4020 is start of Cartridge space, but no cart loaded yet.
-    // Should return 0x00 (or open bus behavior) and NOT crash.
-    assert(mem.read(0x4020) == 0x00);
-
-    log_pass("Bounds & Safety");
-}
-
-void test_controller_input() {
-    nes::PPU ppu;
-    nes::APU apu;
-    nes::Memory mem(ppu, apu);
-
-    // 1. Simulate Player holding 'A' and 'Start' buttons
-    // Standard NES Bit Order: Right Left Down Up Start Sel B A
-    // But our shift register logic usually expects:
-    // Bit 0 = A, Bit 3 = Start. 
-    // Let's set the input byte to 0b00001001 (0x09) -> A and Start are pressed.
+TEST_F(BusFixture, ControllerStrobeAndSerialReadWork) {
     mem.set_controller1(0x09);
     mem.set_controller2(0x09);
 
-    // 2. Perform the "Strobe" Sequence
-    // To read the controller, the game writes 1, then 0 to $4016.
-    mem.write(0x4016, 1); // Strobe ON (Reloads buttons continuously)
-    mem.write(0x4016, 0); // Strobe OFF (Locks current state into shift register)
+    mem.write(0x4016, 1);
+    mem.write(0x4016, 0);
 
-    // 3. Read the buttons one by one (Serial Read)
-    // Expected Sequence: A(1), B(0), Sel(0), Start(1), Up(0), Down(0), Left(0), Right(0)
+    EXPECT_EQ(mem.read(0x4016), 1);
+    EXPECT_EQ(mem.read(0x4016), 0);
+    EXPECT_EQ(mem.read(0x4016), 0);
+    EXPECT_EQ(mem.read(0x4016), 1);
+    EXPECT_EQ(mem.read(0x4016), 0);
+    EXPECT_EQ(mem.read(0x4016), 0);
+    EXPECT_EQ(mem.read(0x4016), 0);
+    EXPECT_EQ(mem.read(0x4016), 0);
 
-    // Controller 1
-    assert(mem.read(0x4016) == 1); // Read 1: A (Pressed)
-    assert(mem.read(0x4016) == 0); // Read 2: B
-    assert(mem.read(0x4016) == 0); // Read 3: Select
-    assert(mem.read(0x4016) == 1); // Read 4: Start (Pressed)
-    assert(mem.read(0x4016) == 0); // Read 5: Up
-    assert(mem.read(0x4016) == 0); // Read 6: Down
-    assert(mem.read(0x4016) == 0); // Read 7: Left
-    assert(mem.read(0x4016) == 0); // Read 8: Right
-
-    // Controller 2
-    assert(mem.read(0x4017) == 1); // Read 1: A (Pressed)
-    assert(mem.read(0x4017) == 0); // Read 2: B
-    assert(mem.read(0x4017) == 0); // Read 3: Select
-    assert(mem.read(0x4017) == 1); // Read 4: Start (Pressed)
-    assert(mem.read(0x4017) == 0); // Read 5: Up
-    assert(mem.read(0x4017) == 0); // Read 6: Down
-    assert(mem.read(0x4017) == 0); // Read 7: Left
-    assert(mem.read(0x4017) == 0); // Read 8: Right
-
-    // 4. Test "Open Bus" or Empty Reads
-    // After 8 reads, the standard NES controller keeps returning 1 (or open bus).
-    // For simple emulation, returning 1 is common to signal "end of data".
-    // assert(mem.read(0x4016) == 1); 
-
-    log_pass("Controller Strobe & Shift Register");
+    EXPECT_EQ(mem.read(0x4017), 1);
+    EXPECT_EQ(mem.read(0x4017), 0);
+    EXPECT_EQ(mem.read(0x4017), 0);
+    EXPECT_EQ(mem.read(0x4017), 1);
+    EXPECT_EQ(mem.read(0x4017), 0);
+    EXPECT_EQ(mem.read(0x4017), 0);
+    EXPECT_EQ(mem.read(0x4017), 0);
+    EXPECT_EQ(mem.read(0x4017), 0);
 }
 
-int main() {
-    std::cout << "Running NES Memory Tests..." << std::endl;
+TEST_F(BusFixture, CartridgePrgMappingReadsThroughMapper) {
+    std::array<uint8_t, 16384> prg{};
+    prg[0x0000] = 0x11;
+    prg[0x3FFC] = 0x34;
+    prg[0x3FFD] = 0x12;
 
-    test_ram_functionality();
-    test_ppu_registers();
-    test_bounds_safety();
-    test_controller_input();
+    mem.set_mapper(std::make_shared<nes::Mapper_000>(1, 1));
+    mem.map_prg(prg.data(), prg.size());
 
-    std::cout << "\nAll tests passed successfully!!" << std::endl;
-    return 0;
+    EXPECT_EQ(mem.read(0x8000), 0x11);
+    EXPECT_EQ(mem.read(0xFFFC), 0x34);
+    EXPECT_EQ(mem.read(0xFFFD), 0x12);
 }
+
+} // namespace

--- a/tests/ppu/ppu_test.cpp
+++ b/tests/ppu/ppu_test.cpp
@@ -1,108 +1,71 @@
-#include <iostream>
-#include <cassert>
-#include "../../include/nes/mem.hpp"
-#include "../../include/nes/ppu.hpp"
-#include "../../include/nes/apu.hpp"
+#include "nes/apu.hpp"
+#include "nes/ppu.hpp"
 
-// A helper to print "PASS" in green
-void log_pass(const char *test_name) {
-    std::cout << "\033[1;32m[PASS] " << test_name << "\033[0m" << std::endl;
-}
+#include <gtest/gtest.h>
 
-void test_ppu_reset() {
+namespace {
+
+TEST(PPUTest, ResetStateIsClean) {
     nes::PPU ppu;
-    nes::APU apu;
-    nes::Memory mem(ppu, apu);
     ppu.reset();
-    assert(ppu.oam_address == 0);
-    assert(ppu.base_nametable_select == 0);
-    assert(ppu.vram_address_increment_flag == false);
-    assert(ppu.sprite_pattern_table_address_flag == false);
-    assert(ppu.background_pattern_table_address_flag == false);
-    assert(ppu.sprite_size_flag == false);
-    assert(ppu.ppu_master_slave_flag == false);
-    assert(ppu.vblank_nmi_flag == false);
-    assert(ppu.greyscale_flag == false);
-    assert(ppu.leftmost_background_flag == false);
-    assert(ppu.leftmost_sprite_flag == false);
-    assert(ppu.background_rendering_flag == false);
-    assert(ppu.sprite_rendering_flag == false);
-    assert(ppu.emphasize_red == false);
-    assert(ppu.emphasize_green == false);
-    assert(ppu.emphasize_blue == false);
-    assert(ppu.sprite_overflow_flag == false);
-    assert(ppu.sprite_zero_hit_flag == false);
-    assert(ppu.vblank_flag == false);
-    assert(ppu.v == 0);
-    assert(ppu.t == 0);
-    assert(ppu.x == 0);
-    assert(ppu.w == false);
-    assert(ppu.data_buffer == 0);
-    assert(ppu.oam_dma_page == 0);
-    assert(ppu.nmi_pending == false);
-    assert(ppu.nmi_prev == false);
-    assert(ppu.frame_complete == false);
-    assert(ppu.vertical_mirroring == false);
-    assert(ppu.open_bus == 0);
-    assert(ppu.timing.odd_frame() == false);
-    assert(ppu.timing.scanline() == -1);
-    assert(ppu.timing.cycle() == 0);
-    assert(ppu.sprites.overflow() == false);
-    // TODO: consider adding accessors to improve testability to sprite and background pipelines
 
-    log_pass("PPU Reset");
+    EXPECT_EQ(ppu.oam_address, 0);
+    EXPECT_EQ(ppu.base_nametable_select, 0);
+    EXPECT_FALSE(ppu.vram_address_increment_flag);
+    EXPECT_FALSE(ppu.sprite_pattern_table_address_flag);
+    EXPECT_FALSE(ppu.background_pattern_table_address_flag);
+    EXPECT_FALSE(ppu.sprite_size_flag);
+    EXPECT_FALSE(ppu.ppu_master_slave_flag);
+    EXPECT_FALSE(ppu.vblank_nmi_flag);
+    EXPECT_FALSE(ppu.greyscale_flag);
+    EXPECT_FALSE(ppu.leftmost_background_flag);
+    EXPECT_FALSE(ppu.leftmost_sprite_flag);
+    EXPECT_FALSE(ppu.background_rendering_flag);
+    EXPECT_FALSE(ppu.sprite_rendering_flag);
+    EXPECT_FALSE(ppu.emphasize_red);
+    EXPECT_FALSE(ppu.emphasize_green);
+    EXPECT_FALSE(ppu.emphasize_blue);
+    EXPECT_FALSE(ppu.sprite_overflow_flag);
+    EXPECT_FALSE(ppu.sprite_zero_hit_flag);
+    EXPECT_TRUE(ppu.vblank_flag);
+    EXPECT_EQ(ppu.v, 0);
+    EXPECT_EQ(ppu.t, 0);
+    EXPECT_EQ(ppu.x, 0);
+    EXPECT_FALSE(ppu.w);
+    EXPECT_EQ(ppu.data_buffer, 0);
+    EXPECT_EQ(ppu.oam_dma_page, 0);
+    EXPECT_FALSE(ppu.nmi_pending);
+    EXPECT_FALSE(ppu.nmi_prev);
+    EXPECT_FALSE(ppu.frame_complete);
+    EXPECT_FALSE(ppu.vertical_mirroring);
+    EXPECT_EQ(ppu.open_bus, 0);
+    EXPECT_FALSE(ppu.timing.odd_frame());
+    EXPECT_EQ(ppu.timing.scanline(), -1);
+    EXPECT_EQ(ppu.timing.cycle(), 0);
+    EXPECT_FALSE(ppu.sprites.overflow());
 }
 
-static void test_sprite_hflip() {
-    std::printf("\n[SpritePipeline horizontal flip]\n");
-
-    assert(nes::SpritePipeline::maybe_flipped_h(0x00, 0b10110001) == 0b10110001);
-    log_pass("no-flip attribute returns byte unchanged");
-
-    assert(nes::SpritePipeline::maybe_flipped_h(0x40, 0b10110001) == (uint8_t)0b10001101);
-    log_pass("flip attribute reverses all 8 bits");
-
-    assert(nes::SpritePipeline::maybe_flipped_h(0x40, 0x00) == 0x00);
-    log_pass("flipping 0x00 is stable");
-
-    assert(nes::SpritePipeline::maybe_flipped_h(0x40, 0xFF) == 0xFF);
-    log_pass("flipping 0xFF is stable");
+TEST(PPUTest, HorizontalFlipHelperReversesBits) {
+    EXPECT_EQ(nes::SpritePipeline::maybe_flipped_h(0x00, 0b10110001), 0b10110001);
+    EXPECT_EQ(nes::SpritePipeline::maybe_flipped_h(0x40, 0b10110001), static_cast<uint8_t>(0b10001101));
+    EXPECT_EQ(nes::SpritePipeline::maybe_flipped_h(0x40, 0x00), 0x00);
+    EXPECT_EQ(nes::SpritePipeline::maybe_flipped_h(0x40, 0xFF), 0xFF);
 }
 
-static void test_vblank_flag_via_step() {
-    std::printf("\n[VBlank flag via step()]\n");
-    {
-        nes::PPU ppu;
-        bool found = false;
-        for (int i = 0; i < 100000 && !found; i++) {
-            ppu.step();
-            if (ppu.vblank_flag) found = true;
-        }
+TEST(PPUTest, VBlankFlagAppearsDuringStepAndClearsOnStatusRead) {
+    nes::PPU ppu;
 
-        assert(found == true);
-        assert(ppu.vblank_flag == true);
-
-        log_pass("step() sets vblank_flag at scanline 241 cycle 1");
+    bool found_vblank = false;
+    for (int i = 0; i < 100000 && !found_vblank; ++i) {
+        ppu.step();
+        found_vblank = ppu.vblank_flag;
     }
-    {
-        nes::PPU ppu;
-        for (int i = 0; i < 100000 && !ppu.vblank_flag; i++) ppu.step();
-        assert(ppu.vblank_flag == true);
 
-        ppu.cpu_read_register(0x2002);
-        assert(ppu.vblank_flag == false);
+    EXPECT_TRUE(found_vblank);
+    EXPECT_TRUE(ppu.vblank_flag);
 
-        log_pass("reading PPUSTATUS clears vblank_flag set by step()");
-    }
+    ppu.cpu_read_register(0x2002);
+    EXPECT_FALSE(ppu.vblank_flag);
 }
 
-int main() {
-    std::cout << "Running NES PPU Tests..." << std::endl;
-
-    test_ppu_reset();
-    test_sprite_hflip();
-    test_vblank_flag_via_step();
-
-    std::cout << "\nAll tests passed successfully!!" << std::endl;
-    return 0;
-}
+} // namespace

--- a/tests/support/test_utils.hpp
+++ b/tests/support/test_utils.hpp
@@ -1,0 +1,27 @@
+#pragma once
+
+#include <filesystem>
+#include <string>
+#include <vector>
+
+namespace test_support {
+
+inline std::string find_nestest_rom() {
+    namespace fs = std::filesystem;
+
+    const std::vector<std::string> candidates = {
+        "./tests/test_roms/nestest/nestest.nes",
+        "../tests/test_roms/nestest/nestest.nes",
+        "../../tests/test_roms/nestest/nestest.nes",
+    };
+
+    for (const auto& path : candidates) {
+        if (fs::exists(path)) {
+            return path;
+        }
+    }
+
+    return "";
+}
+
+} // namespace test_support

--- a/tests/test_sanity.cpp
+++ b/tests/test_sanity.cpp
@@ -1,53 +1,22 @@
-#include <cstdio>
-#include <filesystem>
-#include <string>
-#include <vector>
-
 #include "nes/console.hpp"
 
-static std::string find_nestest_rom() {
-    namespace fs = std::filesystem;
+#include <gtest/gtest.h>
 
-    const std::vector<std::string> candidates = {
-        "./tests/test_roms/nestest/nestest.nes",
-        "../tests/test_roms/nestest/nestest.nes",
-        "../../tests/test_roms/nestest/nestest.nes",
-    };
+#include <string>
 
-    for (const auto& p : candidates) {
-        if (fs::exists(p)) return p;
-    }
-    return "";
-}
+#include "support/test_utils.hpp"
 
-int main() {
-    std::printf("[sanity] starting...\n");
-
+TEST(IntegrationSmokeTest, ConsoleAdvancesCpuCycles) {
     console con;
 
-    const std::string rom_path = find_nestest_rom();
-    if (rom_path.empty()) {
-        std::fprintf(stderr, "[sanity] FAIL: could not locate nestest.nes\n");
-        return 1;
-    }
+    const std::string rom_path = test_support::find_nestest_rom();
+    ASSERT_FALSE(rom_path.empty()) << "Could not locate nestest.nes";
+    ASSERT_TRUE(con.load_rom(rom_path.c_str()));
 
-    // console::load_rom takes char*, but it doesn't modify the string.
-    if (!con.load_rom(const_cast<char*>(rom_path.c_str()))) {
-        std::fprintf(stderr, "[sanity] FAIL: load_rom failed: %s\n", rom_path.c_str());
-        return 1;
-    }
+    const unsigned long long before = con.get_cpu_cycles();
+    const int used = con.step_instruction();
+    const unsigned long long after = con.get_cpu_cycles();
 
-    unsigned long long c0 = con.get_cpu_cycles();
-    int used = con.step_instruction();
-    unsigned long long c1 = con.get_cpu_cycles();
-
-    if (c1 <= c0) {
-        std::fprintf(stderr,
-                     "[sanity] FAIL: cpu cycles did not advance (%llu -> %llu), used=%d\n",
-                     c0, c1, used);
-        return 1;
-    }
-
-    std::printf("[sanity] PASS: cpu_cycles %llu -> %llu (used=%d)\n", c0, c1, used);
-    return 0;
+    EXPECT_GT(after, before);
+    EXPECT_GT(used, 0);
 }

--- a/tests/timing/timing_tests.cpp
+++ b/tests/timing/timing_tests.cpp
@@ -1,0 +1,44 @@
+#include "nes/timing.hpp"
+#include "nes/ppu.hpp"
+
+#include <gtest/gtest.h>
+
+namespace {
+
+TEST(TimingTest, ConstantsMatchNtscTiming) {
+    EXPECT_EQ(CPU_TO_PPU, 3);
+    EXPECT_EQ(PPU_CYCLES_PER_FRAME, 89342);
+}
+
+TEST(ScanlineTest, StartsAtPrerenderLine) {
+    nes::Scanline scanline;
+
+    EXPECT_TRUE(scanline.is_prerender_scanline());
+    EXPECT_TRUE(scanline.is_frame_start());
+    EXPECT_EQ(scanline.scanline(), -1);
+    EXPECT_EQ(scanline.cycle(), 0u);
+}
+
+TEST(ScanlineTest, ReachesVBlankStartAndNextFrame) {
+    nes::Scanline scanline;
+
+    bool saw_vblank = false;
+    for (int i = 0; i < 100000 && !saw_vblank; ++i) {
+        scanline.tick(true);
+        saw_vblank = scanline.is_vblank_start();
+    }
+
+    EXPECT_TRUE(saw_vblank);
+    EXPECT_TRUE(scanline.is_vblank_start());
+
+    bool saw_new_frame = false;
+    for (int i = 0; i < 100000 && !saw_new_frame; ++i) {
+        scanline.tick(true);
+        saw_new_frame = scanline.frame_count() > 0;
+    }
+
+    EXPECT_TRUE(saw_new_frame);
+    EXPECT_GE(scanline.frame_count(), 1u);
+}
+
+} // namespace

--- a/tests/ui/audio_tests.cpp
+++ b/tests/ui/audio_tests.cpp
@@ -1,0 +1,22 @@
+#include "ui/audio.hpp"
+#include "nes/console.hpp"
+
+#include <gtest/gtest.h>
+
+namespace {
+
+TEST(AudioStreamTest, InitializesWithDefaultSampleRate) {
+    console emu;
+    ui::AudioStream stream(emu);
+
+    EXPECT_TRUE(stream.initialize());
+}
+
+TEST(AudioStreamTest, InitializesWithCustomSampleRate) {
+    console emu;
+    ui::AudioStream stream(emu);
+
+    EXPECT_TRUE(stream.initialize(22050));
+}
+
+} // namespace

--- a/tests/ui/ui_tests.cpp
+++ b/tests/ui/ui_tests.cpp
@@ -1,0 +1,62 @@
+#include "ui/ui.hpp"
+#include "nes/console.hpp"
+
+#include <gtest/gtest.h>
+
+namespace {
+
+TEST(UiInputTest, PressAndReleaseAUpdatesControllerBit) {
+    console emu;
+
+    sf::Event press{};
+    press.type = sf::Event::KeyPressed;
+    press.key.code = sf::Keyboard::Z;
+    ui::process_input(press, emu);
+    EXPECT_NE(emu.get_mem().get_controller1() & ui::A, 0);
+
+    sf::Event release{};
+    release.type = sf::Event::KeyReleased;
+    release.key.code = sf::Keyboard::Z;
+    ui::process_input(release, emu);
+    EXPECT_EQ(emu.get_mem().get_controller1() & ui::A, 0);
+}
+
+TEST(UiInputTest, DirectionalAndStartButtonsMapCorrectly) {
+    console emu;
+
+    sf::Event up_press{};
+    up_press.type = sf::Event::KeyPressed;
+    up_press.key.code = sf::Keyboard::Up;
+    ui::process_input(up_press, emu);
+
+    sf::Event start_press{};
+    start_press.type = sf::Event::KeyPressed;
+    start_press.key.code = sf::Keyboard::Enter;
+    ui::process_input(start_press, emu);
+
+    const uint8_t state = emu.get_mem().get_controller1();
+    EXPECT_NE(state & ui::UP, 0);
+    EXPECT_NE(state & ui::START, 0);
+
+    sf::Event up_release{};
+    up_release.type = sf::Event::KeyReleased;
+    up_release.key.code = sf::Keyboard::Up;
+    ui::process_input(up_release, emu);
+
+    EXPECT_EQ(emu.get_mem().get_controller1() & ui::UP, 0);
+    EXPECT_NE(emu.get_mem().get_controller1() & ui::START, 0);
+}
+
+TEST(UiInputTest, NonGameplayKeysAreIgnored) {
+    console emu;
+    emu.get_mem().set_controller1(0x5A);
+
+    sf::Event press{};
+    press.type = sf::Event::KeyPressed;
+    press.key.code = sf::Keyboard::Q;
+    ui::process_input(press, emu);
+
+    EXPECT_EQ(emu.get_mem().get_controller1(), 0x5A);
+}
+
+} // namespace


### PR DESCRIPTION
There is a lot of code to look over, but here is the gist:
- FIxed a bug in mapper 000 where you could write to CHR-RAM when you should not be able too
- Fixed a bug in the APU test
- Added tests for all mappers, the console, UI,  audio bridge, cpu, and timing
- Updated rom, mem, and ppu tests to use the gtest suite
- Added some utils to help sanity check the test roms in some test cases
- Updated the tests CmakeList

You can now run `make build && make test` to see the tests in action. Right now we have all tests passing, but there are still some issues with the PPU when running scrolling games, so more test coverage or updated tests may need to be made.

Edit: I made a typo in the PR title and idk how to change it 😭