### PR TITLE
Add dual-player keyboard mappings for single-keyboard.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,6 +54,7 @@ target_include_directories(nes_lib
 add_library(nes_ui STATIC
         ${PROJECT_SOURCE_DIR}/src/ui/ui.cpp
         ${PROJECT_SOURCE_DIR}/src/ui/audio.cpp
+        ${PROJECT_SOURCE_DIR}/src/ui/keybinds.cpp
 )
 target_include_directories(nes_ui
         PUBLIC
@@ -95,28 +96,27 @@ elseif(APPLE)
     target_link_libraries(nes_ui PUBLIC "-framework AppKit")
 endif()
 
-# Silence warning only for NFD sources (GNU/Clang only)
-set_source_files_properties(${NFD_SOURCES} PROPERTIES
-        COMPILE_FLAGS "$<$<C_COMPILER_ID:GNU,Clang>:-Wno-format-truncation>"
-)
+# Silence warnings only for NFD third-party sources
+if(APPLE)
+    set_source_files_properties(${NFD_SOURCES} PROPERTIES
+            COMPILE_FLAGS "-Wno-deprecated-declarations"
+    )
+elseif(CMAKE_C_COMPILER_ID MATCHES "GNU|Clang")
+    set_source_files_properties(${NFD_SOURCES} PROPERTIES
+            COMPILE_FLAGS "-Wno-format-truncation"
+    )
+endif()
 
-# Link UI target with SFML, nes_lib and gtest
-target_link_libraries(nes_ui PUBLIC sfml-graphics sfml-window sfml-system sfml-audio nes_lib GTest::gtest_main GTest::gtest)
+# Link UI target with SFML, emulator core, and gtest
+target_link_libraries(nes_ui PUBLIC sfml-graphics sfml-window sfml-system sfml-audio GTest::gtest_main GTest::gtest)
+target_link_libraries(nes_ui PRIVATE nes_lib)
 if(TGUI_FOUND)
     target_link_libraries(nes_ui PUBLIC TGUI::TGUI)
 endif()
 
-# ---- Executable with main.cpp; link SDL, and UI ----
-add_executable(nes_emu ${PROJECT_SOURCE_DIR}/src/main.cpp
-        include/nes/ppu.hpp
-        include/nes/component.hpp
-        include/nes/timing.hpp
-        include/nes/apu.hpp
-        src/nes/ROM.cpp
-        src/nes/apu.cpp
-        src/nes/ppu.cpp
-)
-target_link_libraries(nes_emu PRIVATE nes_lib nes_ui)
+# ---- Executable with main.cpp; link emulator core and UI ----
+add_executable(nes_emu ${PROJECT_SOURCE_DIR}/src/main.cpp)
+target_link_libraries(nes_emu PRIVATE nes_ui)
 
 # ---- Tests ----
 option(BUILD_TESTING "Build tests" ON)

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ A cross-platform NES emulator built as part of the OSU CS-461/462 Capstone proje
 
 
 ## Current Status
-The project is under active development. Core system scaffolding is in place, with CPU, memory, and ROM loading under implementation. Rendering and input are handled through SDL2.
+The project is under active development. Core system scaffolding is in place, with CPU, memory, and ROM loading under implementation. Rendering and input are handled through SFML.
 
 ## Repository Structure
 ```text
@@ -18,13 +18,13 @@ build/          Out-of-source build artifacts
 - **Memory** – NES memory map and mirroring
 - **PPU** – Graphics pipeline and framebuffer
 - **ROM Loader** – iNES parsing and PRG/CHR mapping
-- **Input** – NES controller state via SDL events
+- **Input** – NES controller state via SFML events
 
 
 ## Tech
 - **Language:** C++20
 - **Build:** CMake (+ Makefile shim)
-- **Window/Input/Rendering:** SDL2
+- **Window/Input/Rendering:** SFML
 - **CI:** GitHub Actions (Linux/macOS/Windows)
 - **Tests:** basic test harness for build validation (functional tests in progress)
 
@@ -32,7 +32,7 @@ build/          Out-of-source build artifacts
 
 ### macOS
 ```bash
-brew install sdl2 cmake googletest sfml@2
+brew install cmake googletest sfml@2
 make build
 make run
 make test
@@ -40,7 +40,7 @@ make test
 
 ### Ubuntu/Debian
 ```bash
-sudo apt-get update && sudo apt-get install -y libsdl2-dev cmake g++ libgtest-dev libgmock-dev libsfml-dev
+sudo apt-get update && sudo apt-get install -y cmake g++ libgtest-dev libgmock-dev libsfml-dev
 sudo cmake -S /usr/src/googletest -B /tmp/build-gtest
 sudo cmake --build /tmp/build-gtest --config Release
 sudo cmake --install /tmp/build-gtest
@@ -55,7 +55,7 @@ PowerShell:
 cd C:\
 git clone https://github.com/microsoft/vcpkg.git
 C:\vcpkg\bootstrap-vcpkg.bat
-C:\vcpkg\vcpkg install sdl2:x64-windows gtest:x64-windows
+C:\vcpkg\vcpkg install sfml:x64-windows gtest:x64-windows
 C:\vcpkg\vcpkg integrate install
 Switch to local project directory
 choco install -y cmake
@@ -70,6 +70,59 @@ cmake --build build --config Release
 
 ## Running ROMs
 ROM loading is under active development. At this stage, the emulator validates the toolchain and core system scaffolding but does not yet fully execute commercial NES ROMs.
+
+## Controls
+
+Default keyboard layout keeps the original single-player controls on player 1 and adds a second keyboard layout for player 2.
+
+Player 1 uses the original controls:
+- Movement: arrow keys
+- `A` button: `Z`
+- `B` button: `X`
+- `Select`: `Right Shift`
+- `Start`: `Return`
+
+Player 2 uses the alternate controls:
+- Movement: `W`, `A`, `S`, `D`
+- `A` button: `F`
+- `B` button: `G`
+- `Select`: `Left Shift`
+- `Start`: `Tab`
+
+Emulator hotkeys:
+- Pause/resume: `Space`
+- Step one frame: `F2`
+- Reset: `R`
+- Toggle fullscreen: `F11`
+- Load ROM: `O`
+- Quit: `Escape`
+
+## Changing Key Bindings
+
+On first launch, the emulator creates `keybinds.ini` in the working directory. Edit that file and restart the emulator to apply changes.
+
+The file has three sections:
+- `[player1]` for controller 1
+- `[player2]` for controller 2
+- `[emulator]` for emulator hotkeys
+
+Example:
+
+```ini
+[player1]
+up     = Up
+down   = Down
+left   = Left
+right  = Right
+a      = Z
+b      = X
+select = RShift
+start  = Return
+```
+
+Use SFML key names such as `A`, `Space`, `Return`, `LShift`, `Comma`, `Period`, `Up`, or `F11`.
+
+Each action must have a unique key. If the same key is assigned to more than one action, the later conflicting entry is reset to its default binding when the file is loaded.
 
 
 ## Contributing

--- a/include/ui/keybinds.hpp
+++ b/include/ui/keybinds.hpp
@@ -1,0 +1,31 @@
+#pragma once
+#include <SFML/Window/Keyboard.hpp>
+#include <string>
+
+namespace ui {
+    // one controller's worth of key bindings
+    struct PlayerKeys {
+        sf::Keyboard::Key up, down, left, right;
+        sf::Keyboard::Key a, b, select, start;
+    };
+
+    // emulator-level hotkeys (not sent to the NES)
+    struct EmuKeys {
+        sf::Keyboard::Key pause, step_frame, reset, fullscreen, load_rom, quit;
+    };
+
+    struct KeyBinds {
+        PlayerKeys p1, p2; // p1 = left side of keyboard, p2 = right side
+        EmuKeys emu;
+
+        // returns the built-in default layout
+        static KeyBinds defaults();
+        // loads from an INI file; creates the file with defaults if it doesn't exist
+        static KeyBinds load_or_create(const std::string& path);
+    };
+
+    // converts a key name string (e.g. "LShift") to the matching SFML key code
+    sf::Keyboard::Key key_from_string(const std::string& name);
+    // converts an SFML key code back to its name string for writing to the config file
+    std::string key_to_string(sf::Keyboard::Key key);
+}

--- a/src/ui/keybinds.cpp
+++ b/src/ui/keybinds.cpp
@@ -1,0 +1,301 @@
+#include "ui/keybinds.hpp"
+#include <fstream>
+#include <cstdio>
+
+namespace {
+    struct KeyName {
+        const char* name;
+        sf::Keyboard::Key key;
+    };
+
+    static const KeyName k_key_names[] = {
+        {"A", sf::Keyboard::A}, {"B", sf::Keyboard::B}, {"C", sf::Keyboard::C},
+        {"D", sf::Keyboard::D}, {"E", sf::Keyboard::E}, {"F", sf::Keyboard::F},
+        {"G", sf::Keyboard::G}, {"H", sf::Keyboard::H}, {"I", sf::Keyboard::I},
+        {"J", sf::Keyboard::J}, {"K", sf::Keyboard::K}, {"L", sf::Keyboard::L},
+        {"M", sf::Keyboard::M}, {"N", sf::Keyboard::N}, {"O", sf::Keyboard::O},
+        {"P", sf::Keyboard::P}, {"Q", sf::Keyboard::Q}, {"R", sf::Keyboard::R},
+        {"S", sf::Keyboard::S}, {"T", sf::Keyboard::T}, {"U", sf::Keyboard::U},
+        {"V", sf::Keyboard::V}, {"W", sf::Keyboard::W}, {"X", sf::Keyboard::X},
+        {"Y", sf::Keyboard::Y}, {"Z", sf::Keyboard::Z},
+        {"Num0", sf::Keyboard::Num0}, {"Num1", sf::Keyboard::Num1},
+        {"Num2", sf::Keyboard::Num2}, {"Num3", sf::Keyboard::Num3},
+        {"Num4", sf::Keyboard::Num4}, {"Num5", sf::Keyboard::Num5},
+        {"Num6", sf::Keyboard::Num6}, {"Num7", sf::Keyboard::Num7},
+        {"Num8", sf::Keyboard::Num8}, {"Num9", sf::Keyboard::Num9},
+        {"Numpad0", sf::Keyboard::Numpad0}, {"Numpad1", sf::Keyboard::Numpad1},
+        {"Numpad2", sf::Keyboard::Numpad2}, {"Numpad3", sf::Keyboard::Numpad3},
+        {"Numpad4", sf::Keyboard::Numpad4}, {"Numpad5", sf::Keyboard::Numpad5},
+        {"Numpad6", sf::Keyboard::Numpad6}, {"Numpad7", sf::Keyboard::Numpad7},
+        {"Numpad8", sf::Keyboard::Numpad8}, {"Numpad9", sf::Keyboard::Numpad9},
+        {"F1", sf::Keyboard::F1}, {"F2", sf::Keyboard::F2},
+        {"F3", sf::Keyboard::F3}, {"F4", sf::Keyboard::F4},
+        {"F5", sf::Keyboard::F5}, {"F6", sf::Keyboard::F6},
+        {"F7", sf::Keyboard::F7}, {"F8", sf::Keyboard::F8},
+        {"F9", sf::Keyboard::F9}, {"F10", sf::Keyboard::F10},
+        {"F11", sf::Keyboard::F11}, {"F12", sf::Keyboard::F12},
+        {"F13", sf::Keyboard::F13}, {"F14", sf::Keyboard::F14},
+        {"F15", sf::Keyboard::F15},
+        {"Up", sf::Keyboard::Up}, {"Down", sf::Keyboard::Down},
+        {"Left", sf::Keyboard::Left}, {"Right", sf::Keyboard::Right},
+        {"Home", sf::Keyboard::Home}, {"End", sf::Keyboard::End},
+        {"PageUp", sf::Keyboard::PageUp}, {"PageDown", sf::Keyboard::PageDown},
+        {"Insert", sf::Keyboard::Insert}, {"Delete", sf::Keyboard::Delete},
+        {"LShift", sf::Keyboard::LShift}, {"RShift", sf::Keyboard::RShift},
+        {"LControl", sf::Keyboard::LControl}, {"RControl", sf::Keyboard::RControl},
+        {"LAlt", sf::Keyboard::LAlt}, {"RAlt", sf::Keyboard::RAlt},
+        {"Space", sf::Keyboard::Space}, {"Return", sf::Keyboard::Return},
+        {"BackSpace", sf::Keyboard::BackSpace}, {"Tab", sf::Keyboard::Tab},
+        {"LBracket", sf::Keyboard::LBracket}, {"RBracket", sf::Keyboard::RBracket},
+        {"SemiColon", sf::Keyboard::SemiColon}, {"Comma", sf::Keyboard::Comma},
+        {"Period", sf::Keyboard::Period}, {"Quote", sf::Keyboard::Quote},
+        {"Slash", sf::Keyboard::Slash}, {"BackSlash", sf::Keyboard::BackSlash},
+        {"Tilde", sf::Keyboard::Tilde}, {"Equal", sf::Keyboard::Equal},
+        {"Dash", sf::Keyboard::Dash},
+        {"Escape", sf::Keyboard::Escape}, {"Pause", sf::Keyboard::Pause},
+    };
+
+    struct KeyField {
+        const char* label;
+        sf::Keyboard::Key* key;
+        sf::Keyboard::Key default_key;
+    };
+
+// strips leading and trailing whitespace from a string
+    static std::string trim(const std::string& s) {
+        std::string::size_type a = s.find_first_not_of(" \t\r\n");
+        std::string::size_type b;
+        if (a == std::string::npos) return "";
+        b = s.find_last_not_of(" \t\r\n");
+        return s.substr(a, b - a + 1);
+    }
+
+    static KeyField key_fields(ui::KeyBinds& kb, const ui::KeyBinds& defaults, int index) {
+        switch (index) {
+            case 0: return {"player1.up", &kb.p1.up, defaults.p1.up};
+            case 1: return {"player1.down", &kb.p1.down, defaults.p1.down};
+            case 2: return {"player1.left", &kb.p1.left, defaults.p1.left};
+            case 3: return {"player1.right", &kb.p1.right, defaults.p1.right};
+            case 4: return {"player1.a", &kb.p1.a, defaults.p1.a};
+            case 5: return {"player1.b", &kb.p1.b, defaults.p1.b};
+            case 6: return {"player1.select", &kb.p1.select, defaults.p1.select};
+            case 7: return {"player1.start", &kb.p1.start, defaults.p1.start};
+            case 8: return {"player2.up", &kb.p2.up, defaults.p2.up};
+            case 9: return {"player2.down", &kb.p2.down, defaults.p2.down};
+            case 10: return {"player2.left", &kb.p2.left, defaults.p2.left};
+            case 11: return {"player2.right", &kb.p2.right, defaults.p2.right};
+            case 12: return {"player2.a", &kb.p2.a, defaults.p2.a};
+            case 13: return {"player2.b", &kb.p2.b, defaults.p2.b};
+            case 14: return {"player2.select", &kb.p2.select, defaults.p2.select};
+            case 15: return {"player2.start", &kb.p2.start, defaults.p2.start};
+            case 16: return {"emulator.pause", &kb.emu.pause, defaults.emu.pause};
+            case 17: return {"emulator.step_frame", &kb.emu.step_frame, defaults.emu.step_frame};
+            case 18: return {"emulator.reset", &kb.emu.reset, defaults.emu.reset};
+            case 19: return {"emulator.fullscreen", &kb.emu.fullscreen, defaults.emu.fullscreen};
+            case 20: return {"emulator.load_rom", &kb.emu.load_rom, defaults.emu.load_rom};
+            default: return {"emulator.quit", &kb.emu.quit, defaults.emu.quit};
+        }
+    }
+
+    static void validate_bindings(ui::KeyBinds& kb) {
+        const ui::KeyBinds defaults = ui::KeyBinds::defaults();
+        const int field_count = 22;
+        int i;
+        int j;
+
+        for (i = 0; i < field_count; ++i) {
+            KeyField a = key_fields(kb, defaults, i);
+            if (*a.key == sf::Keyboard::Unknown) {
+                *a.key = a.default_key;
+            }
+        }
+
+        for (i = 0; i < field_count; ++i) {
+            KeyField a = key_fields(kb, defaults, i);
+            for (j = i + 1; j < field_count; ++j) {
+                KeyField b = key_fields(kb, defaults, j);
+                if (*a.key != *b.key) continue;
+
+                std::fprintf(stderr,
+                             "[UI] Duplicate key binding for %s and %s (%s). Resetting %s to %s.\n",
+                             a.label,
+                             b.label,
+                             ui::key_to_string(*a.key).c_str(),
+                             b.label,
+                             ui::key_to_string(b.default_key).c_str());
+                *b.key = b.default_key;
+            }
+        }
+    }
+}
+
+namespace ui {
+    sf::Keyboard::Key key_from_string(const std::string& name) {
+        size_t i;
+        for (i = 0; i < sizeof(k_key_names) / sizeof(k_key_names[0]); ++i) {
+            if (name == k_key_names[i].name) {
+                return k_key_names[i].key;
+            }
+        }
+        return sf::Keyboard::Unknown;
+    }
+
+    std::string key_to_string(sf::Keyboard::Key key) {
+        size_t i;
+        for (i = 0; i < sizeof(k_key_names) / sizeof(k_key_names[0]); ++i) {
+            if (key == k_key_names[i].key) {
+                return k_key_names[i].name;
+            }
+        }
+        return "Unknown";
+    }
+
+    KeyBinds KeyBinds::defaults() {
+        KeyBinds kb;
+        kb.p1.up = sf::Keyboard::Up;
+        kb.p1.down = sf::Keyboard::Down;
+        kb.p1.left = sf::Keyboard::Left;
+        kb.p1.right = sf::Keyboard::Right;
+        kb.p1.a = sf::Keyboard::Z;
+        kb.p1.b = sf::Keyboard::X;
+        kb.p1.select = sf::Keyboard::RShift;
+        kb.p1.start = sf::Keyboard::Return;
+
+        kb.p2.up = sf::Keyboard::W;
+        kb.p2.down = sf::Keyboard::S;
+        kb.p2.left = sf::Keyboard::A;
+        kb.p2.right = sf::Keyboard::D;
+        kb.p2.a = sf::Keyboard::F;
+        kb.p2.b = sf::Keyboard::G;
+        kb.p2.select = sf::Keyboard::LShift;
+        kb.p2.start = sf::Keyboard::Tab;
+
+        kb.emu.pause = sf::Keyboard::Space;
+        kb.emu.step_frame = sf::Keyboard::F2;
+        kb.emu.reset = sf::Keyboard::R;
+        kb.emu.fullscreen = sf::Keyboard::F11;
+        kb.emu.load_rom = sf::Keyboard::O;
+        kb.emu.quit = sf::Keyboard::Escape;
+        return kb;
+    }
+
+// writes a fully-commented default keybinds.ini so the user has something to edit
+    static void write_defaults(const std::string& path, const KeyBinds& kb) {
+        std::ofstream f(path.c_str());
+        if (!f.is_open()) return;
+
+        f << "# NES Emulator key bindings\n"
+          << "# Edit this file to remap controls, then restart the emulator.\n"
+          << "# Duplicate keys are not allowed; conflicting entries fall back to defaults.\n"
+          << "#\n"
+          << "# Supported key names:\n"
+          << "#   Letters : A B C ... Z\n"
+          << "#   Numbers : Num0 Num1 ... Num9\n"
+          << "#   Numpad  : Numpad0 Numpad1 ... Numpad9\n"
+          << "#   Function: F1 F2 ... F15\n"
+          << "#   Arrows  : Up Down Left Right\n"
+          << "#   Special : Space Return BackSpace Tab Escape Pause\n"
+          << "#             LShift RShift LControl RControl LAlt RAlt\n"
+          << "#             LBracket RBracket SemiColon Comma Period\n"
+          << "#             Quote Slash BackSlash Tilde Equal Dash\n"
+          << "#             Home End PageUp PageDown Insert Delete\n"
+          << "\n"
+          << "[player1]\n"
+          << "up     = " << key_to_string(kb.p1.up) << "\n"
+          << "down   = " << key_to_string(kb.p1.down) << "\n"
+          << "left   = " << key_to_string(kb.p1.left) << "\n"
+          << "right  = " << key_to_string(kb.p1.right) << "\n"
+          << "a      = " << key_to_string(kb.p1.a) << "\n"
+          << "b      = " << key_to_string(kb.p1.b) << "\n"
+          << "select = " << key_to_string(kb.p1.select) << "\n"
+          << "start  = " << key_to_string(kb.p1.start) << "\n"
+          << "\n"
+          << "[player2]\n"
+          << "up     = " << key_to_string(kb.p2.up) << "\n"
+          << "down   = " << key_to_string(kb.p2.down) << "\n"
+          << "left   = " << key_to_string(kb.p2.left) << "\n"
+          << "right  = " << key_to_string(kb.p2.right) << "\n"
+          << "a      = " << key_to_string(kb.p2.a) << "\n"
+          << "b      = " << key_to_string(kb.p2.b) << "\n"
+          << "select = " << key_to_string(kb.p2.select) << "\n"
+          << "start  = " << key_to_string(kb.p2.start) << "\n"
+          << "\n"
+          << "[emulator]\n"
+          << "pause      = " << key_to_string(kb.emu.pause) << "\n"
+          << "step_frame = " << key_to_string(kb.emu.step_frame) << "\n"
+          << "reset      = " << key_to_string(kb.emu.reset) << "\n"
+          << "fullscreen = " << key_to_string(kb.emu.fullscreen) << "\n"
+          << "load_rom   = " << key_to_string(kb.emu.load_rom) << "\n"
+          << "quit       = " << key_to_string(kb.emu.quit) << "\n";
+    }
+
+    KeyBinds KeyBinds::load_or_create(const std::string& path) {
+        KeyBinds kb = defaults();
+        std::ifstream file(path.c_str());
+        std::string line;
+        std::string section;
+
+        if (!file.is_open()) {
+            write_defaults(path, kb);
+            std::fprintf(stderr, "[UI] Created default keybinds: %s\n", path.c_str());
+            return kb;
+        }
+
+        while (std::getline(file, line)) {
+            line = trim(line);
+            if (line.empty() || line[0] == '#' || line[0] == ';') continue;
+
+            if (line[0] == '[') {
+                std::string::size_type end = line.find(']');
+                if (end != std::string::npos) {
+                    section = trim(line.substr(1, end - 1));
+                }
+                continue;
+            }
+
+            std::string::size_type eq = line.find('=');
+            if (eq == std::string::npos) continue;
+
+            std::string field = trim(line.substr(0, eq));
+            sf::Keyboard::Key k = key_from_string(trim(line.substr(eq + 1)));
+            if (k == sf::Keyboard::Unknown) {
+                std::fprintf(stderr,
+                             "[UI] Ignoring unknown key name for %s.%s\n",
+                             section.c_str(),
+                             field.c_str());
+                continue;
+            }
+
+            if (section == "player1") {
+                if      (field == "up")     kb.p1.up = k;
+                else if (field == "down")   kb.p1.down = k;
+                else if (field == "left")   kb.p1.left = k;
+                else if (field == "right")  kb.p1.right = k;
+                else if (field == "a")      kb.p1.a = k;
+                else if (field == "b")      kb.p1.b = k;
+                else if (field == "select") kb.p1.select = k;
+                else if (field == "start")  kb.p1.start = k;
+            } else if (section == "player2") {
+                if      (field == "up")     kb.p2.up = k;
+                else if (field == "down")   kb.p2.down = k;
+                else if (field == "left")   kb.p2.left = k;
+                else if (field == "right")  kb.p2.right = k;
+                else if (field == "a")      kb.p2.a = k;
+                else if (field == "b")      kb.p2.b = k;
+                else if (field == "select") kb.p2.select = k;
+                else if (field == "start")  kb.p2.start = k;
+            } else if (section == "emulator") {
+                if      (field == "pause")      kb.emu.pause = k;
+                else if (field == "step_frame") kb.emu.step_frame = k;
+                else if (field == "reset")      kb.emu.reset = k;
+                else if (field == "fullscreen") kb.emu.fullscreen = k;
+                else if (field == "load_rom")   kb.emu.load_rom = k;
+                else if (field == "quit")       kb.emu.quit = k;
+            }
+        }
+
+        validate_bindings(kb);
+        std::fprintf(stderr, "[UI] Loaded keybinds: %s\n", path.c_str());
+        return kb;
+    }
+}

--- a/src/ui/ui.cpp
+++ b/src/ui/ui.cpp
@@ -1,11 +1,13 @@
 #include "ui/ui.hpp"
 #include "ui/audio.hpp"
+#include "ui/keybinds.hpp"
 #include "nes/console.hpp"
 #include <SFML/Graphics.hpp>
 #include <algorithm>
 
 namespace {
     sf::RenderWindow* g_window = nullptr;
+    ui::KeyBinds g_keybinds = ui::KeyBinds::defaults(); // loaded from keybinds.ini on init()
     sf::Texture g_texture;
     sf::Sprite g_sprite;
     std::unique_ptr<ui::AudioStream> g_audioStream = nullptr;
@@ -36,6 +38,35 @@ namespace {
         // Ensure the view covers the whole window
         ::g_window->setView(sf::View(sf::FloatRect(0.f, 0.f, static_cast<float>(winSize.x), static_cast<float>(winSize.y))));
     }
+
+    static uint8_t button_for_key(const ui::PlayerKeys& keys, sf::Keyboard::Key key) {
+        if (key == keys.up) return ui::UP;
+        if (key == keys.down) return ui::DOWN;
+        if (key == keys.left) return ui::LEFT;
+        if (key == keys.right) return ui::RIGHT;
+        if (key == keys.a) return ui::A;
+        if (key == keys.b) return ui::B;
+        if (key == keys.select) return ui::SELECT;
+        if (key == keys.start) return ui::START;
+        return 0;
+    }
+
+    static void update_controller_state(console& emu, int player, uint8_t mask, bool pressed) {
+        uint8_t state;
+        if (mask == 0) return;
+
+        if (player == 1) {
+            state = emu.get_mem().get_controller1();
+            state = pressed ? static_cast<uint8_t>(state | mask)
+                            : static_cast<uint8_t>(state & static_cast<uint8_t>(~mask));
+            emu.get_mem().set_controller1(state);
+        } else {
+            state = emu.get_mem().get_controller2();
+            state = pressed ? static_cast<uint8_t>(state | mask)
+                            : static_cast<uint8_t>(state & static_cast<uint8_t>(~mask));
+            emu.get_mem().set_controller2(state);
+        }
+    }
 }
 
 namespace ui {
@@ -64,6 +95,8 @@ namespace ui {
     }
 
     bool init() {
+        // load keybinds from file; creates keybinds.ini with defaults if missing
+        ::g_keybinds = ui::KeyBinds::load_or_create("keybinds.ini");
         try {
             ::g_window = new sf::RenderWindow(
                 sf::VideoMode(FB_WIDTH * SCALE, FB_HEIGHT * SCALE),
@@ -121,62 +154,16 @@ namespace ui {
     }
 
     void process_input(sf::Event& event, console& emu) {
-        // check if event is a keyboard event
         if (event.type != sf::Event::KeyPressed && event.type != sf::Event::KeyReleased)
             return;
-        
-        // is key pressed
+
         bool pressed = (event.type == sf::Event::KeyPressed);
-        // temp container for nes button bit
-        uint8_t mask = 0;
+        sf::Keyboard::Key k = event.key.code;
+        uint8_t p1_mask = button_for_key(::g_keybinds.p1, k);
+        uint8_t p2_mask = button_for_key(::g_keybinds.p2, k);
 
-        // map of nes controller bits
-        switch (event.key.code) {
-            case sf::Keyboard::Z: {
-                mask = A;
-                break;
-            }
-            case sf::Keyboard::X: {
-                mask = B;
-                break;
-            }
-            case sf::Keyboard::RShift: {
-                mask = SELECT;
-                break;
-            }
-            case sf::Keyboard::Enter: {
-                mask = START;
-                break;
-            }
-            case sf::Keyboard::Up: {
-                mask = UP;
-                break;
-            }
-            case sf::Keyboard::Down: {
-                mask = DOWN;
-                break;
-            }
-            case sf::Keyboard::Left: {
-                mask = LEFT;
-                break;
-            }
-            case sf::Keyboard::Right: {
-                mask = RIGHT;
-                break;
-            }
-            default:
-                return; // not a gameplay key
-        }
-
-        // check if a key is pressed
-        if (pressed) {
-            emu.get_mem().set_controller1(emu.get_mem().get_controller1() | mask);
-            // console output
-            std::printf("Button Pressed: %02X | Current State: %02X\n", mask, emu.get_mem().get_controller1());
-        }
-        else {
-            emu.get_mem().set_controller1(emu.get_mem().get_controller1() & ~mask);
-        }
+        update_controller_state(emu, 1, p1_mask, pressed);
+        update_controller_state(emu, 2, p2_mask, pressed);
     }
     
     bool step(console& emu, bool& is_running) {
@@ -195,77 +182,46 @@ namespace ui {
                 ::g_window->close();
                 return false;
             }
-            // Handle keyboard input for controlling the emulator
-            // Space - toggle pause/resume
-            // S - step one frame
-            // R - reset emulator
-            // F - toggle fullscreen
-            // L - load ROM
-            auto tppe = event.type;
-            if (event.type == sf::Event::KeyPressed){
-                switch (event.key.code)
-                {
-                    case sf::Keyboard::Escape:
+            if (event.type == sf::Event::KeyPressed) {
+                const ui::EmuKeys& ek = ::g_keybinds.emu; // emulator hotkeys loaded from keybinds.ini
+                sf::Keyboard::Key k = event.key.code;
+
+                if (k == ek.quit) {
+                    is_running = false;
+                    ::g_window->close();
+                    return false;
+                } else if (k == ek.pause && emu.rom_loaded()) {
+                    is_running = !is_running;
+                    std::fprintf(stderr, is_running ? "Resuming emulation\n" : "Pausing emulation\n");
+                } else if (k == ek.step_frame && emu.rom_loaded()) {
+                    std::fprintf(stderr, "Stepping one frame\n");
+                    emu.step(1);
+                } else if (k == ek.reset && emu.rom_loaded()) {
+                    std::fprintf(stderr, "Resetting emulator\n");
+                    emu.reset_all();
+                    is_running = false;
+                } else if (k == ek.fullscreen && emu.rom_loaded()) {
+                    std::fprintf(stderr, "Toggling fullscreen\n");
+                    if (::g_fullscreen)
+                        ::g_window->create(sf::VideoMode(FB_WIDTH * SCALE, FB_HEIGHT * SCALE), "NES Emulator", sf::Style::Default);
+                    else
+                        ::g_window->create(sf::VideoMode::getDesktopMode(), "NES Emulator", sf::Style::Fullscreen);
+                    ::g_window->setFramerateLimit(60);
+                    ::g_fullscreen = !::g_fullscreen;
+                    update_view();
+                } else if (k == ek.load_rom) {
+                    if (emu.rom_loaded()) {
+                        std::fprintf(stderr, "Unloading current ROM\n");
+                        emu.reset_all();
                         is_running = false;
-                        ::g_window->close();
-                        return false;
-                        break;
-                    case sf::Keyboard::Space:
-                        if (emu.rom_loaded()) {
-                            if (!is_running) {
-                                std::fprintf(stderr, "Resuming emulation\n");
-                            } else {
-                                std::fprintf(stderr, "Pausing emulation\n");
-                            }
-                            is_running = !is_running;
-                        }
-                        break;
-                    case sf::Keyboard::S:
-                        if (emu.rom_loaded()) {
-                            std::fprintf(stderr, "Stepping one frame\n");
-                            emu.step(1);
-                        }
-                        break;
-                    case sf::Keyboard::R:
-                        if (emu.rom_loaded()) {
-                            std::fprintf(stderr, "Resetting emulator\n");
-                            emu.reset_all();
-                            is_running = false;
-                        }
-                        break;
-                    case sf::Keyboard::F:
-                        if (emu.rom_loaded()) {
-                            std::fprintf(stderr, "Toggling fullscreen\n");
-                            if (::g_fullscreen) {
-                                ::g_window->create(sf::VideoMode(FB_WIDTH * SCALE, FB_HEIGHT * SCALE), "NES Emulator", sf::Style::Default);
-                            } else {
-                                ::g_window->create(sf::VideoMode::getDesktopMode(), "NES Emulator", sf::Style::Fullscreen);
-                            }
-                            // Reapply settings for the new window
-                            ::g_window->setFramerateLimit(60);
-                            ::g_fullscreen = !::g_fullscreen;
-                            update_view();
-                        }
-                        break;
-                    case sf::Keyboard::L:{
-                        if (emu.rom_loaded()) {
-                            // unload rom
-                            std::fprintf(stderr, "Unloading current ROM\n");
-                            emu.reset_all();
-                            is_running = false;
-                        }
-                        // add file select menu
-                        std::string filePath = openFileDialog();
-                        if (!filePath.empty()) {
-                            std::fprintf(stderr, "Loading ROM: %s\n", filePath.c_str());
-                            emu.load_rom(filePath.c_str());
-                            init_audio(emu);
-                            is_running = true;
-                        }
                     }
-                        break;
-                    default:
-                        break;
+                    std::string filePath = openFileDialog();
+                    if (!filePath.empty()) {
+                        std::fprintf(stderr, "Loading ROM: %s\n", filePath.c_str());
+                        emu.load_rom(filePath.c_str());
+                        init_audio(emu);
+                        is_running = true;
+                    }
                 }
             }
         }


### PR DESCRIPTION
Add custom keyboard mapping capability
Kept original keyboard settings as the default for player 1.

Clean-up build messages on Mac
Clean-up duplicate libnes_lib.a generation

closes #100 
closes #101 