### PR TITLE
Fix bug with audio and clean up code

### DIFF
--- a/include/nes/ROM.hpp
+++ b/include/nes/ROM.hpp
@@ -3,11 +3,7 @@
 #include <cstddef>
 #include <vector>
 #include <memory>
-#include "mapper/mapper_000.hpp"
-#include "mapper/mapper_001.hpp"
-#include "mapper/mapper_002.hpp"
-#include "mapper/mapper_003.hpp"
-#include "mapper/mapper_004.hpp"
+#include "nes/mapper/mapper.hpp"
 
 // TODO: Make the iNES ROM spec a struct and parse it in a more structured way.
 

--- a/include/nes/ROM.hpp
+++ b/include/nes/ROM.hpp
@@ -2,7 +2,6 @@
 #include <cstdint>
 #include <cstddef>
 #include <vector>
-#include <string>
 #include <memory>
 #include "mapper/mapper_000.hpp"
 #include "mapper/mapper_001.hpp"

--- a/include/nes/apu.hpp
+++ b/include/nes/apu.hpp
@@ -1,8 +1,8 @@
 #pragma once
 #include <cstdint>
 #include <cstddef>
-#include <deque>
-#include <mutex>
+#include <vector>
+#include <atomic>
 #include "nes/timing.hpp"
 
 namespace nes {
@@ -166,7 +166,6 @@ public:
 // The triangle channel has no volume control; the waveform is either
 // cycling or suspended.  It includes a linear counter for finer-grained
 // duration control than the length counter alone.
-// Timer ticks at CPU clock rate (not halved like Pulse/Noise).
 class Triangle {
 public:
     void write_register(uint8_t reg, uint8_t value);
@@ -361,9 +360,15 @@ private:
     // (very bad, horrid bugs and potential memory leaks)
     static constexpr size_t MAX_QUEUED_SAMPLES = static_cast<size_t>(AUDIO_SAMPLE_RATE);
 
+    // Lock-free single-producer single-consumer ring buffer for PCM samples.
+    // Producer (APU::step) writes samples; consumer (audio thread) calls
+    // drain_samples(). The buffer capacity is a power-of-two >= MAX_QUEUED_SAMPLES.
+    std::vector<int16_t>  m_sample_ring;
+    size_t                m_sample_capacity = 0; // power-of-two
+    size_t                m_sample_mask     = 0;
+    std::atomic<size_t>   m_sample_head{0}; // producer index (next write)
+    std::atomic<size_t>   m_sample_tail{0}; // consumer index (next read)
     double                m_sample_accumulator = 0.0;
-    std::deque<int16_t>   m_sample_queue;
-    mutable std::mutex    m_sample_mutex;
 
     uint64_t cpu_cycle     = 0;
     uint8_t  status_enable = 0;

--- a/include/nes/console.hpp
+++ b/include/nes/console.hpp
@@ -1,7 +1,6 @@
 #pragma once
 
 #include <cstdint>
-#include <cstddef>
 
 #include "nes/ROM.hpp"
 #include "nes/cpu.hpp"

--- a/include/nes/mem.hpp
+++ b/include/nes/mem.hpp
@@ -1,7 +1,5 @@
 #pragma once
 #include <cstdint>
-#include <cstddef>
-#include <memory>
 
 namespace nes {
 

--- a/include/ui/audio.hpp
+++ b/include/ui/audio.hpp
@@ -10,7 +10,7 @@ namespace ui {
 
 class AudioStream : public sf::SoundStream {
     public:
-        AudioStream(console& emu);
+        explicit AudioStream(console& emu);
         ~AudioStream();
 
         bool initialize(unsigned int sampleRate = 44100);
@@ -20,8 +20,9 @@ class AudioStream : public sf::SoundStream {
         void onSeek(sf::Time timeOffset) override;
 
         console& m_emu;
-        std::vector<int16_t> m_buffer;
+        std::vector<int16_t> m_chunkBuffer;
         unsigned int m_sampleRate;
+        size_t m_chunkSamples = 0; // number of samples (not frames) per chunk
 
         // When the APU queue runs dry we repeat the last sample rather than
         // emitting a click.  This avoids a harsh pop on underrun.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -33,8 +33,10 @@ int main(int argc, char** argv) {
     // (e.g. 44100.8 Hz instead of 44100 Hz)
     // this fixes one of the most annoying bugs I have seen where the audio is just *slightly* wrong
     // I knew I wasn't crazy...
+    // Edit from later: turns out the CPU_HZ was a lie, we need to take the cycles from the clock directly
     double cycle_accumulator = 0.0;
-    constexpr double CYCLES_PER_FRAME = CPU_HZ / 60.0; // ~29829.54...
+    // constexpr double CYCLES_PER_FRAME = CPU_HZ / 60.0; // ~29829.54...
+    constexpr double CYCLES_PER_FRAME = static_cast<double>(PPU_CYCLES_PER_FRAME) / static_cast<double>(CPU_TO_PPU);
 
     while (ui::step(emu, is_running)) {
         if (is_running) {
@@ -50,6 +52,6 @@ int main(int argc, char** argv) {
     // Cleanup
     ui::shutdown();
     std::fprintf(stderr, "Exiting\n");
-    
+
     return 0;
 }

--- a/src/nes/ROM.cpp
+++ b/src/nes/ROM.cpp
@@ -1,4 +1,9 @@
 #include "nes/ROM.hpp"
+#include "nes/mapper/mapper_000.hpp"
+#include "nes/mapper/mapper_001.hpp"
+#include "nes/mapper/mapper_002.hpp"
+#include "nes/mapper/mapper_003.hpp"
+#include "nes/mapper/mapper_004.hpp"
 #include <fstream>
 #include <array>
 #include <algorithm>
@@ -78,10 +83,10 @@ namespace nes {
         // Read header
         std::array<uint8_t, HEADER_SIZE> header{};
         if (!read_exact(header.data(), header.size())) return false;
-        
+
         // Validate iNES magic header
         if (!std::equal(header.begin(), header.begin() + 4, NES_MAGIC)) return false;
-    
+
         // ROM sizes (in banks)
         const std::size_t prg_bank_count = header[4];
         const std::size_t chr_bank_count = header[5];

--- a/src/nes/apu.cpp
+++ b/src/nes/apu.cpp
@@ -1,7 +1,7 @@
 #include "nes/apu.hpp"
 #include "nes/mem.hpp"
 #include <algorithm>
-#include <mutex>
+#include <cstring>
 
 namespace nes {
 
@@ -586,12 +586,17 @@ void APU::reset()
     noise.reset();
     dmc.reset();
 
-    // Flush any stale audio samples so the stream starts clean
-    // must be done after resetting the channels since they may have pending samples in the queue
-    // mutex is needed to avoid race conditions with the audio callback thread that may be draining samples at the same time
+    // Initialize and flush the sample ring buffer so the stream starts clean.
+    // This must be done after resetting the channels since they may have
+    // pending samples in the queue.
     {
-        std::lock_guard<std::mutex> lock(m_sample_mutex);
-        m_sample_queue.clear();
+        size_t cap = 1;
+        while (cap < MAX_QUEUED_SAMPLES) cap <<= 1;
+        m_sample_capacity = cap;
+        m_sample_mask = cap - 1;
+        m_sample_ring.assign(m_sample_capacity, 0);
+        m_sample_head.store(0);
+        m_sample_tail.store(0);
     }
     m_sample_accumulator = 0.0;
 }
@@ -689,9 +694,18 @@ void APU::step()
         if (s < -1.0f) s = -1.0f;
         const int16_t sample = static_cast<int16_t>(s * 32767.0f);
 
-        std::lock_guard<std::mutex> lock(m_sample_mutex);
-        if (m_sample_queue.size() < MAX_QUEUED_SAMPLES)
-            m_sample_queue.push_back(sample);
+        // Lock-free push into SPSC ring buffer.  Drop samples if the queue
+        // is already at the configured MAX_QUEUED_SAMPLES.
+        {
+            const size_t head = m_sample_head.load(std::memory_order_relaxed);
+            const size_t tail = m_sample_tail.load(std::memory_order_acquire);
+            const size_t used = head - tail;
+            if (used < MAX_QUEUED_SAMPLES)
+            {
+                m_sample_ring[head & m_sample_mask] = sample;
+                m_sample_head.store(head + 1, std::memory_order_release);
+            }
+        }
     }
 }
 
@@ -810,14 +824,23 @@ float APU::get_output() const
 
 size_t APU::drain_samples(int16_t* out, size_t count)
 {
-    std::lock_guard<std::mutex> lock(m_sample_mutex);
-    const size_t available = std::min(m_sample_queue.size(), count);
-    for (size_t i = 0; i < available; ++i)
-    {
-        out[i] = m_sample_queue.front();
-        m_sample_queue.pop_front();
-    }
-    return available;
+    const size_t head = m_sample_head.load(std::memory_order_acquire);
+    const size_t tail = m_sample_tail.load(std::memory_order_relaxed);
+    const size_t available = (head - tail);
+    const size_t to_read = std::min(available, count);
+
+    if (to_read == 0)
+        return 0;
+
+    const size_t idx = tail & m_sample_mask;
+    const size_t first = std::min(to_read, m_sample_capacity - idx);
+
+    std::memcpy(out, &m_sample_ring[idx], first * sizeof(int16_t));
+    if (to_read > first)
+        std::memcpy(out + first, &m_sample_ring[0], (to_read - first) * sizeof(int16_t));
+
+    m_sample_tail.store(tail + to_read, std::memory_order_release);
+    return to_read;
 }
 
 //                     95.88

--- a/src/nes/console.cpp
+++ b/src/nes/console.cpp
@@ -1,7 +1,6 @@
 #include "nes/console.hpp"
 #include <cstdio>
 #include <cstring>
-#include <cstddef>
 
 console::console()
     : rom(),
@@ -20,7 +19,7 @@ bool console::load_rom(const char* filepath) {
         std::fprintf(stderr, "[console] Failed to load ROM: %s\n", filepath);
         return false;
     }
-    
+
     mem.insert_cartridge(&rom);
     ppu.insert_cartridge(&rom);
 

--- a/src/nes/mem.cpp
+++ b/src/nes/mem.cpp
@@ -1,6 +1,5 @@
 #include "nes/mem.hpp"
 #include <cstring>
-#include <cstdio>
 #include "nes/apu.hpp"
 #include "nes/ppu.hpp"
 #include "nes/ROM.hpp"

--- a/src/ui/audio.cpp
+++ b/src/ui/audio.cpp
@@ -1,18 +1,30 @@
 #include "ui/audio.hpp"
 #include "nes/console.hpp"
+#include <cmath>
+#include <algorithm>
 
 namespace ui {
 
     AudioStream::AudioStream(console& emu)
-        : m_emu(emu), m_sampleRate(44100), m_lastSample(0)
+        : m_emu(emu), m_sampleRate(44100), m_lastSample(0), m_chunkSamples(0)
     {
-        m_buffer.reserve(4096);
+        // Reserve a modest default to avoid reallocations before initialize()
+        m_chunkBuffer.reserve(4096);
     }
 
     AudioStream::~AudioStream() = default; // default destructor is fine since we don't have any manual resource management
 
     bool AudioStream::initialize(unsigned int sampleRate) {
         m_sampleRate = sampleRate;
+
+        // Calculate chunk size based on PPU timing so we emit an integral number of samples per emulated frame.
+        // This reduces systematic drift when the NES timing isn't exactly 60.0 Hz.
+        const double frame_rate = PPU_HZ / static_cast<double>(PPU_CYCLES_PER_FRAME);
+        const size_t CHUNK_SIZE = static_cast<size_t>(std::lround(static_cast<double>(m_sampleRate) / frame_rate));
+
+        m_chunkSamples = CHUNK_SIZE; // number of samples (mono)
+        m_chunkBuffer.resize(m_chunkSamples);
+
         // Mono audio at the requested sample rate.
         sf::SoundStream::initialize(1, m_sampleRate);
         return true;
@@ -24,27 +36,27 @@ namespace ui {
     // buffer size is large relative to one emulation frame), we hold the
     // last known sample to avoid a harsh click/pop.
     bool AudioStream::onGetData(Chunk& data) {
-        // Use a fixed chunk size.  735 samples = 44100 / 60, which matches
-        // exactly one NES frame at 60 fps.  Keeping this small minimises
-        // latency; SFML will call us again immediately if needed.
-        constexpr size_t CHUNK_SIZE = 735;
+        if (m_chunkSamples == 0) {
+            // Not initialized; fall back to a safe default.
+            m_chunkSamples = 2048;
+            m_chunkBuffer.resize(m_chunkSamples);
+        }
 
-        m_buffer.resize(CHUNK_SIZE);
-
-        const size_t received = m_emu.get_apu().drain_samples(m_buffer.data(), CHUNK_SIZE);
+        const size_t received = m_emu.get_apu().drain_samples(m_chunkBuffer.data(), m_chunkSamples);
 
         // Pad any shortfall with the last sample (hold), not silence (zero).
         // This avoids a sharp discontinuity when the emulation thread hasn't
         // produced enough samples yet.
         if (received > 0)
-            m_lastSample = m_buffer[received - 1];
+            m_lastSample = m_chunkBuffer[received - 1];
 
-        for (size_t i = received; i < CHUNK_SIZE; ++i)
-            m_buffer[i] = m_lastSample;
+        if (received < m_chunkSamples) {
+            std::fill(m_chunkBuffer.begin() + received, m_chunkBuffer.end(), m_lastSample);
+        }
 
-        data.samples     = m_buffer.data();
-        data.sampleCount = CHUNK_SIZE;
-        return true; // always return true — stream runs until stopped
+        data.samples     = m_chunkBuffer.data();
+        data.sampleCount = static_cast<unsigned int>(m_chunkBuffer.size());
+        return true; // always return true cuz we want stream to run until stopped later
     }
 
     void AudioStream::onSeek(sf::Time /*timeOffset*/) {


### PR DESCRIPTION
Removed a bunch of unused imports, edited some code comments, and fixed the audio bug by replacing the buffer from before with an SPSC ring buffer to avoid using any mutexes and using the PPU instead of the CPU as the cycle base to sync the audio to the frame rate. This not only fixed the weird audio glitches but also ended up with a noticeable performance improvement.